### PR TITLE
FIX: enable delete bank application when no assessment

### DIFF
--- a/assets/js/finance-id.js
+++ b/assets/js/finance-id.js
@@ -17,8 +17,12 @@ function hideDeleteAssessmentConfirmation() {
   deleteAssessmentBtnEl.hidden = false
 }
 
-deleteAssessmentBtnEl.addEventListener('click', showDeleteAssessmentConfirmation)
-cancelDeleteAssessmentBtnEl.addEventListener('click', hideDeleteAssessmentConfirmation)
+if (deleteAssessmentBtnEl) {
+  deleteAssessmentBtnEl.addEventListener('click', showDeleteAssessmentConfirmation)
+}
+if (cancelDeleteAssessmentBtnEl) {
+  cancelDeleteAssessmentBtnEl.addEventListener('click', hideDeleteAssessmentConfirmation)
+}
 
 /***********************************
   SHOW/HIDE DELETE FINANCE BUTTONS
@@ -39,5 +43,9 @@ function hideDeleteFinanceConfirmation() {
   deleteFinanceBtnEl.hidden = false
 }
 
-deleteFinanceBtnEl.addEventListener('click', showDeleteFinanceConfirmation)
-cancelDeleteFinanceBtnEl.addEventListener('click', hideDeleteFinanceConfirmation)
+if (deleteFinanceBtnEl) {
+  deleteFinanceBtnEl.addEventListener('click', showDeleteFinanceConfirmation)
+}
+if (cancelDeleteFinanceBtnEl) {
+  cancelDeleteFinanceBtnEl.addEventListener('click', hideDeleteFinanceConfirmation)
+}


### PR DESCRIPTION
### Issue

When there is no assessment, the delete button for banking application does not work

### Fix

Add event listeners conditionally