### PR TITLE
RP2-689: reduce timeout to 6 seconds on rp client

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -69,10 +69,10 @@ export default {
     rpClient: {
       url: get('RESETTLEMENT_PASSPORT_API_URL', 'http://localhost:8080'),
       timeout: {
-        response: Number(get('RESETTLEMENT_PASSPORT_API_TIMEOUT_RESPONSE', 10000)),
+        response: Number(get('RESETTLEMENT_PASSPORT_API_TIMEOUT_RESPONSE', 6000)),
         deadline: Number(get('RESETTLEMENT_PASSPORT_API_TIMEOUT_DEADLINE', 10000)),
       },
-      agent: new AgentConfig(Number(get('RESETTLEMENT_PASSPORT_API_TIMEOUT_RESPONSE', 10000))),
+      agent: new AgentConfig(Number(get('RESETTLEMENT_PASSPORT_API_TIMEOUT_RESPONSE', 6000))),
       enabled: get('RESETTLEMENT_PASSPORT_API_ENABLED', 'true') === 'true',
     },
     nomisUserRolesClient: {


### PR DESCRIPTION
6 secs because it meets out 95 percentile on a average day. but we should review this fairly often 