### PR TITLE
PSFR-1026: format and persist address fields.

### DIFF
--- a/server/data/model/BCST2Form.ts
+++ b/server/data/model/BCST2Form.ts
@@ -12,7 +12,7 @@ export type QuestionOptions = {
 export type AnswerType = 'StringAnswer' | 'MapAnswer' | 'ListAnswer'
 
 export type Answer = {
-  answer?: string | string[]
+  answer?: string | string[] | { [key: string]: string }[]
   '@class'?: AnswerType
 }
 
@@ -39,7 +39,7 @@ export type SubmittedQuestionAndAnswer = {
   questionTitle: string
   pageId: string
   answer: {
-    answer: string | string[]
+    answer: string | string[] | { [key: string]: string }[]
     displayText: string
     '@class': AnswerType
   }

--- a/server/utils/formatAssessmentResponse.ts
+++ b/server/utils/formatAssessmentResponse.ts
@@ -37,6 +37,7 @@ const formatAssessmentResponse = (currentPage: string, reqBody: RequestBody) => 
     return {
       question: id,
       questionTitle: title,
+      questionType: type,
       pageId: pageData.id,
       answer: {
         answer: type === 'ADDRESS' ? getAddressValuesFromBody() : reqBody[id],

--- a/server/utils/formatAssessmentResponse.ts
+++ b/server/utils/formatAssessmentResponse.ts
@@ -6,34 +6,45 @@ type RequestBody = {
 
 const formatAssessmentResponse = (currentPage: string, reqBody: RequestBody) => {
   const pageData: AssessmentPage = JSON.parse(currentPage)
+  let radioWithAddressValue: string
 
-  const filteredQuestionsAndAnswers = pageData.questionsAndAnswers
-    .filter(questionAndAnswer => {
-      const { id } = questionAndAnswer.question
-      return reqBody[id] !== null && reqBody[id] !== undefined // only return questions which contain an answer
-    })
-    .map(questionAndAnswer => {
-      const { id, title, type } = questionAndAnswer.question
+  function getAddressValuesFromBody() {
+    return [
+      {
+        [`addressLine1_${radioWithAddressValue}`]: reqBody[`addressLine1_${radioWithAddressValue}`],
+        [`addressLine2_${radioWithAddressValue}`]: reqBody[`addressLine2_${radioWithAddressValue}`],
+        [`addressTown_${radioWithAddressValue}`]: reqBody[`addressTown_${radioWithAddressValue}`],
+        [`addressCounty_${radioWithAddressValue}`]: reqBody[`addressCounty_${radioWithAddressValue}`],
+        [`addressPostcode_${radioWithAddressValue}`]: reqBody[`addressPostcode_${radioWithAddressValue}`],
+      },
+    ]
+  }
 
-      let displayText
-      if (type === 'RADIO' || type === 'RADIO_WITH_ADDRESS' || type === 'DROPDOWN') {
-        displayText = questionAndAnswer.question.options.find(answer => answer.id === reqBody[id]).displayText
-      } else {
-        displayText = ''
-      }
+  const filteredQuestionsAndAnswers = pageData.questionsAndAnswers.map(questionAndAnswer => {
+    const { id, title, type } = questionAndAnswer.question
 
-      return {
-        question: id,
-        questionTitle: title,
-        pageId: pageData.id,
-        pageTitle: pageData.title,
-        answer: {
-          answer: reqBody[id],
-          displayText: displayText || reqBody[id],
-          '@class': 'StringAnswer' as AnswerType,
-        },
-      }
-    })
+    let displayText
+    if (type === 'RADIO' || type === 'RADIO_WITH_ADDRESS' || type === 'DROPDOWN') {
+      displayText = questionAndAnswer.question.options.find(answer => answer.id === reqBody[id]).displayText
+    } else {
+      displayText = ''
+    }
+
+    if (type === 'RADIO_WITH_ADDRESS') {
+      radioWithAddressValue = reqBody[id]
+    }
+
+    return {
+      question: id,
+      questionTitle: title,
+      pageId: pageData.id,
+      answer: {
+        answer: type === 'ADDRESS' ? getAddressValuesFromBody() : reqBody[id],
+        displayText: displayText || reqBody[id],
+        '@class': (type === 'ADDRESS' ? 'MapAnswer' : 'StringAnswer') as AnswerType,
+      },
+    }
+  })
 
   const formattedResponse: SubmittedInput = {
     questionsAndAnswers: filteredQuestionsAndAnswers,

--- a/server/views/macros/checkAnswers.njk
+++ b/server/views/macros/checkAnswers.njk
@@ -7,7 +7,17 @@
       {% if questionAnswer.question !== 'SUPPORT_NEEDS' and questionAnswer.question !== 'CASE_NOTE_SUMMARY' %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">{{ questionAnswer.questionTitle }}</dt>
-          <dd class="govuk-summary-list__value">{{ questionAnswer.answer.displayText }}</dd>
+          <dd class="govuk-summary-list__value">
+            {% if questionAnswer.questionType === 'ADDRESS' %}
+              {% for key, value in questionAnswer.answer.answer[0] %}
+                {% if value %}
+                  {{ value }}<br />
+                {% endif %}
+              {% endfor %}
+            {% else %}
+              {{ questionAnswer.answer.displayText }}
+            {% endif %}
+          </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link govuk-link--no-visited-state" href="/BCST2/pathway/{{ pathway }}/page/{{ questionAnswer.pageId }}?prisonerNumber={{ prisonerNumber }}">Change</a>
           </dd>

--- a/server/views/macros/radio-with-address.njk
+++ b/server/views/macros/radio-with-address.njk
@@ -1,23 +1,60 @@
-{% macro radioWithAddress(currentQuestionAndAnswer, existingAnswer, isFirstQuestionOnPage) %}
+{% macro radioWithAddress(currentQuestionAndAnswer, existingAnswer, isFirstQuestionOnPage, addressQuestionAndAnswer, nextQuestionExistingAnswer) %}
   {% if not isFirstQuestionOnPage %}
     <b>{{ currentQuestionAndAnswer.question.title }}</b>
   {% endif %}
-  <div class="govuk-radios" data-module="govuk-radios">
-    {% for option in currentQuestionAndAnswer.question.options %}
-      <div class="govuk-radios__item">
-        <input
-          class="govuk-radios__input"
-          id="{{ option.id }}"
-          name="{{ currentQuestionAndAnswer.question.id }}"
-          type="radio"
-          value="{{ option.id }}"
-          {% if existingAnswer.answer == option.id %}
-            checked
+
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <div class="govuk-radios" data-module="govuk-radios">
+        {% for option in currentQuestionAndAnswer.question.options %}
+          <div class="govuk-radios__item">
+            <input
+              class="govuk-radios__input"
+              id="{{ option.id }}"
+              name="{{ currentQuestionAndAnswer.question.id }}"
+              type="radio"
+              value="{{ option.id }}"
+              data-aria-controls="conditional-{{ option.id }}"
+              {% if existingAnswer.answer == option.id %}
+                checked
+              {% endif %}
+            />
+            <label class="govuk-label govuk-radios__label" for="{{ option.id }}">{{ option.displayText }}</label>
+            <div class="govuk-hint govuk-radios__hint">{{ option.description }}</div>
+          </div>
+          {% if not loop.last %}
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-{{ option.id }}">
+              <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                    <h2 class="govuk-fieldset__heading">{{ addressQuestionAndAnswer.question.title }}</h2>
+                  </legend>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-line-1-{{ option.id }}">Address line 1</label>
+                    <input class="govuk-input govuk-!-width-two-thirds" id="address-line-1-{{ option.id }}" name="addressLine1_{{ option.id }}" type="text" autocomplete="address-line1" value="{{ nextQuestionExistingAnswer.answer[0]['addressLine1_' + option.id] }}">
+                  </div>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-line-2-{{ option.id }}">Address line 2 (optional)</label>
+                    <input class="govuk-input govuk-!-width-two-thirds" id="address-line-2-{{ option.id }}" name="addressLine2_{{ option.id }}" type="text" autocomplete="address-line2" value="{{ nextQuestionExistingAnswer.answer[0]['addressLine2_' + option.id] }}">
+                  </div>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-town-{{ option.id }}">Town or city</label>
+                    <input class="govuk-input govuk-!-width-one-half" id="address-town-{{ option.id }}" name="addressTown_{{ option.id }}" type="text" autocomplete="address-level2" value="{{ nextQuestionExistingAnswer.answer[0]['addressTown_' + option.id] }}">
+                  </div>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-county-{{ option.id }}">County (optional)</label>
+                    <input class="govuk-input govuk-!-width-one-half" id="address-county-{{ option.id }}" name="addressCounty_{{ option.id }}" type="text" value="{{ nextQuestionExistingAnswer.answer[0]['addressCounty_' + option.id] }}">
+                  </div>
+                  <div class="govuk-form-group">
+                    <label class="govuk-label" for="address-postcode-{{ option.id }}">Postcode</label>
+                    <input class="govuk-input govuk-input--width-10" id="address-postcode-{{ option.id }}" name="addressPostcode_{{ option.id }}" type="text" autocomplete="postal-code" value="{{ nextQuestionExistingAnswer.answer[0]['addressPostcode_' + option.id] }}">
+                  </div>
+                </fieldset>
+              </div>
+            </div>
           {% endif %}
-        />
-        <label class="govuk-label govuk-radios__label" for="{{ option.id }}">{{ option.displayText }}</label>
-        <div class="govuk-hint govuk-radios__hint">{{ option.description }}</div>
+        {% endfor %}
       </div>
-    {% endfor %}
+    </fieldset>
   </div>
 {% endmacro %}

--- a/server/views/pages/BCST2-form.njk
+++ b/server/views/pages/BCST2-form.njk
@@ -55,13 +55,16 @@
 
               {# get answer to current question #}
               {% set existingAnswer = currentQuestionAndAnswer | getAnswerToCurrentQuestion(allQuestionsAndAnswers) %}
-
-              {% if loop.index == 1 %}
+              {% set currentIndex = loop.index %}
+              {% if currentIndex == 1 %}
                 {% set isFirstQuestionOnPage = true %}
               {% endif %}
 
               {% if currentQuestionAndAnswer.question.type === 'RADIO_WITH_ADDRESS' %}
-                {{ radioWithAddress(currentQuestionAndAnswer, existingAnswer, isFirstQuestionOnPage) }}
+                {# get the next question and answer (ADDRESS) item in the array #}
+                {% set nextQuestionAndAnswer = assessmentPage.questionsAndAnswers[currentIndex] %}
+                {% set nextQuestionExistingAnswer = nextQuestionAndAnswer | getAnswerToCurrentQuestion(allQuestionsAndAnswers) %}
+                {{ radioWithAddress(currentQuestionAndAnswer, existingAnswer, isFirstQuestionOnPage, nextQuestionAndAnswer, nextQuestionExistingAnswer) }}
               {% elif currentQuestionAndAnswer.question.type === 'RADIO' %}
                 {{ radio(currentQuestionAndAnswer, existingAnswer, isFirstQuestionOnPage) }}
               {% elif currentQuestionAndAnswer.question.type === 'LONG_TEXT' %}
@@ -70,7 +73,7 @@
                 {{ dropDown(currentQuestionAndAnswer, existingAnswer, isFirstQuestionOnPage) }}
               {% elif currentQuestionAndAnswer.question.type === 'LIST_OF_PEOPLE' %}
                 {{ listOfPeople(currentQuestionAndAnswer, existingAnswer, isFirstQuestionOnPage) }}
-              {% else %}
+              {% elif not currentQuestionAndAnswer.question.type === 'RADIO_WITH_ADDRESS' %}
                 <p class="govuk-error-message govuk-!-padding-top-6">There was a problem getting the next question.<br /> Please try again. <a class="govuk-link" href="{{ feedbackUrl }}">Contact us</a> if the problem still occurs</p>
               {% endif %}
             {% endfor %}


### PR DESCRIPTION
**Changes made:**

- Conditionally nest and reveal the address fields inside the radio buttons - first two options only.
- Persist input data and pre-populate with existing answers when navigating back
- If you select the first radio button, fill in some address data, then change radio button and fill in data again, it should only persist data from the selected radio button, any address answers from the other parent radio button should be ignored.
- Display the Address answers in the check answers page - given values only