### PR TITLE
Add gotenberg to deployment setup

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -30,6 +30,24 @@ services:
     restart: always
     ports:
       - "9091:8080"
+  
+  gotenberg:
+    image: gotenberg/gotenberg:7.7.0
+    networks:
+      - hmpps_int
+    container_name: gotenberg_int
+    ports:
+      - "3001:3001"
+    command:
+      - "gotenberg"
+      - "--api-port=3001"
+      - "--chromium-ignore-certificate-errors"
+      - "--api-timeout=30s"
+      - "--pdfengines-engines=pdftk"
+      - "--uno-listener-restart-threshold=0" #disables uno listener
+    restart: always
+    healthcheck:
+      test: [ 'CMD', 'curl', '-f', 'http://localhost:3001/health' ]
 
 networks:
   hmpps_int:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,23 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
 
+  gotenberg:
+    image: gotenberg/gotenberg:7.7.0
+    networks:
+      - hmpps
+    ports:
+      - "3005:3005"
+    command:
+      - "gotenberg"
+      - "--api-port=3005"
+      - "--chromium-ignore-certificate-errors"
+      - "--api-timeout=30s"
+      - "--pdfengines-engines=pdftk"
+      - "--uno-listener-restart-threshold=0" #disables uno listener
+    restart: on-failure
+    healthcheck:
+      test: [ 'CMD', 'curl', '-f', 'http://localhost:3005/health' ]
+
   app:
     build: .
     networks:

--- a/helm_deploy/hmpps-resettlement-passport-ui/Chart.yaml
+++ b/helm_deploy/hmpps-resettlement-passport-ui/Chart.yaml
@@ -10,3 +10,7 @@ dependencies:
   - name: generic-prometheus-alerts
     version: 1.3.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
+  - name: generic-service
+    alias: gotenberg
+    version: 2.8
+    repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-resettlement-passport-ui/values.yaml
+++ b/helm_deploy/hmpps-resettlement-passport-ui/values.yaml
@@ -57,6 +57,45 @@ generic-service:
       - prisons
       - private_prisons
 
+gotenberg:
+  nameOverride: gotenberg
+  replicaCount: 2
+
+  image:
+    repository: gotenberg/gotenberg
+    tag: 7.7.0
+    port: 3000
+
+  containerCommand: [ "gotenberg" ]
+  containerArgs: [ "--chromium-ignore-certificate-errors","--api-timeout=30s","--pdfengines-engines=pdftk","--uno-listener-restart-threshold=0" ]
+
+  ingress:
+    enabled: false
+
+  livenessProbe:
+    httpGet:
+      path: /health
+    periodSeconds: 30
+    initialDelaySeconds: 60
+    timeoutSeconds: 20
+    failureThreshold: 10
+
+  readinessProbe:
+    httpGet:
+       path: /health
+    periodSeconds: 20
+    initialDelaySeconds: 60
+    timeoutSeconds: 30
+    failureThreshold: 15
+
+  podSecurityContext:
+    fsGroup: 1001
+
+  securityContext:
+    runAsUser: 1001
+    privileged: false
+    runAsNonRoot: true
+      
 generic-prometheus-alerts:
   targetApplication: hmpps-resettlement-passport-ui
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,8 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: "DEV"
     SUPPORT_URL: "https://support-dev.hmpps.service.justice.gov.uk/feedback-and-support"
+    GOTENBERG_API_URL: "http://hmpps-resettlement-passport-ui-gotenberg"
+
 
   allowlist:
     groups:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,6 +18,7 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: "PRE-PRODUCTION"
     SUPPORT_URL: "https://support-preprod.hmpps.service.justice.gov.uk/feedback-and-support"
+    GOTENBERG_API_URL: "http://hmpps-resettlement-passport-ui-gotenberg"
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-resettlement-passport-non-prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,6 +17,7 @@ generic-service:
     DPS_URL: "https://digital.prison.service.justice.gov.uk"
     COMPONENT_API_URL: "https://frontend-components.hmpps.service.justice.gov.uk"
     SUPPORT_URL: "https://support.hmpps.service.justice.gov.uk/feedback-and-support"
+    GOTENBERG_API_URL: "http://hmpps-resettlement-passport-ui-gotenberg"
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-resettlement-passport-prod


### PR DESCRIPTION
We need to generate PDF from HTML markup for [PLT-42](https://project-moj.atlassian.net/browse/PLT-42),
gotenberg seems to be used in another 4 repositories that I can count from the MOJ group, I have done some analysis prior to this and I would like to use gotenberg here too.


Analysis below:

----------------------------------

### PDF rendering options.

Intro: the aim is to dynamically generate a PDF that looks like https://rp-prototype-main.apps.live.cloud-platform.service.justice.gov.uk/public/images/passport-non-digital/paper%20prototype%20v3.pdf. (design now outdated see Jira ticket instead)

There are some challenges to this specific PDF format

Challenged to consider:

- Custom styling, ideally provided as HTML + CSS by designers for easier maintainability, it’s not ideal to try and reproduce from a PDF 

- Maintainability: layout will evolve over time


Technical options available 

**1 Direct rendering with PDFKit**

**Pros**: 
- Does not require external dependencies
- It can render static images from the asset directory
- It can load custom fonts although they need to be downloaded as TIFF format and imported in PDFKit

**Cons:** 
- It is code based which makes it a bit hard to maintain
- it is not html or css syntax,it’s a position based syntax which is a trial and error type of development (you need to know exactly pixel by pixel position etc)


**2 HTML to PDF rendering with Gotenberg**

**Pros:** 
- Can use Nunjuck and HTML syntax which is easier to maintain
- It can render custom fonts
- It can render static images from the asset directory
- It is already used by other teams within the organisation

**Cons:** 
- It can use CSS but has to be in a style block, not imported from a file
- It needs Gutenberg container deployed to k8s cluster, although it has been done by a couple of teams already at MOJ

Discarded options
- Browser Print: by far the easier option would not even need to fetch google maps, although I suspect the customer won’t be happy with this option
- Capture the DOM it would be involving JavaScript in the browser to be enabled, something I believe GOVUK guidance discourage

Conclusions:
I would suggest using Gotenberg like other teams have done (see pre-sentence-service etc on MOJ github)

Proof of concept code:
https://github.com/ministryofjustice/hmpps-resettlement-passport-person-on-probation-ui/compare/main...spike-pdf-gotenberg