### PR TITLE
PSFR-1014: Fix for AC5

### DIFF
--- a/server/routes/BCST2-form/BCST2FormController.ts
+++ b/server/routes/BCST2-form/BCST2FormController.ts
@@ -51,6 +51,8 @@ export default class BCST2FormController {
       const { token } = req.user
       const { pathway, currentPageId } = req.body
       const edit = req.body.edit === 'true'
+      const backButton = req.query.backButton === 'true'
+
       const store = new AssessmentStore(createRedisClient())
       const currentPage = await store.getCurrentPage(
         req.session.id,
@@ -105,7 +107,7 @@ export default class BCST2FormController {
       if (validationErrors) {
         const validationErrorsString = encodeURIComponent(JSON.stringify(validationErrors))
         return res.redirect(
-          `/BCST2/pathway/${pathway}/page/${currentPageId}?prisonerNumber=${prisonerData.personalDetails.prisonerNumber}&validationErrors=${validationErrorsString}${editQueryString}`,
+          `/BCST2/pathway/${pathway}/page/${currentPageId}?prisonerNumber=${prisonerData.personalDetails.prisonerNumber}&validationErrors=${validationErrorsString}${editQueryString}&backButton=${backButton}`,
         )
       }
 
@@ -113,7 +115,7 @@ export default class BCST2FormController {
         const { nextPageId } = nextPage
 
         return res.redirect(
-          `/BCST2/pathway/${pathway}/page/${nextPageId}?prisonerNumber=${prisonerData.personalDetails.prisonerNumber}${editQueryString}`,
+          `/BCST2/pathway/${pathway}/page/${nextPageId}?prisonerNumber=${prisonerData.personalDetails.prisonerNumber}${editQueryString}&backButton=${backButton}`,
         )
       }
       return next(new Error(nextPage.error))
@@ -129,6 +131,7 @@ export default class BCST2FormController {
       const { pathway, currentPageId } = req.params
       const edit = req.query.edit === 'true'
       const submitted = req.query.submitted === 'true'
+      const backButton = req.query.backButton === 'true'
       const validationErrorsString = req.query.validationErrors as string
       const validationErrors: ValidationErrors = validationErrorsString
         ? JSON.parse(decodeURIComponent(validationErrorsString))
@@ -320,6 +323,7 @@ export default class BCST2FormController {
         validationErrors,
         edit,
         submitted,
+        backButton,
       )
       return res.render('pages/BCST2-form', { ...view.renderArgs })
     } catch (err) {

--- a/server/routes/BCST2-form/BCST2FormView.ts
+++ b/server/routes/BCST2-form/BCST2FormView.ts
@@ -11,6 +11,7 @@ export default class BCST2FormView implements View {
     private readonly validationErrors: ValidationErrors,
     private readonly edit: boolean,
     private readonly submitted: boolean,
+    private readonly backButton: boolean,
     private readonly errors: ErrorMessage[] = [],
   ) {}
 
@@ -22,6 +23,7 @@ export default class BCST2FormView implements View {
     validationErrors: ValidationErrors
     edit: boolean
     submitted: boolean
+    backButton: boolean
     errors: ErrorMessage[]
   } {
     return {
@@ -32,6 +34,7 @@ export default class BCST2FormView implements View {
       validationErrors: this.validationErrors,
       edit: this.edit,
       submitted: this.submitted,
+      backButton: this.backButton,
       errors: this.errors.length !== 0 ? this.errors : null,
     }
   }

--- a/server/views/pages/BCST2-form.njk
+++ b/server/views/pages/BCST2-form.njk
@@ -31,7 +31,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
 
-        {% if submitted or not edit %}
+        {% if submitted or backButton or not edit %}
           <button class="govuk-back-link assessment-back-button">Back</button>
         {% endif %}
         
@@ -45,7 +45,7 @@
             {% if assessmentPage.id == 'CHECK_ANSWERS' %}
               action="/BCST2/pathway/{{ pathway }}/complete?prisonerNumber={{ prisonerData.personalDetails.prisonerNumber }}"
             {% else %}
-              action="/BCST2-next-page/?prisonerNumber={{ prisonerData.personalDetails.prisonerNumber }}"
+              action="/BCST2-next-page/?prisonerNumber={{ prisonerData.personalDetails.prisonerNumber }}&backButton={{true if backButton or submitted}}"
             {% endif %}
             method="post"
           >


### PR DESCRIPTION
AC5 - Edit form response - second question onwards

Given the user has clicked to edit a form response for any question in the Resettlement Assessment form

And has already submitted the first selected question

And is on a subsequent question page

When clicking the ‘Back’ link

Then direct the user to the previous question page