### PR TITLE
RSP-1849: Block support needs for legacy profiles

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -60,6 +60,7 @@ export type PrisonerData = {
   resettlementReviewAvailable: boolean
   immediateNeedsSubmitted: boolean
   preReleaseSubmitted: boolean
+  supportNeedsLegacyProfile?: boolean
 }
 
 export type PathwayStatus = {

--- a/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
+++ b/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
@@ -338,9 +338,11 @@ exports[`getView Happy path - ensure support need for legacy profile renders cor
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/accommodation/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/accommodation/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1173,9 +1175,11 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/accommodation/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/accommodation/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -2192,9 +2196,11 @@ exports[`getView Happy path with default query params and no data from endpoints
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/accommodation/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/accommodation/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -2670,9 +2676,11 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/accommodation/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/accommodation/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     

--- a/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
+++ b/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
@@ -330,9 +330,11 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/attitudes-thinking-and-behaviour/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/attitudes-thinking-and-behaviour/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1274,9 +1276,11 @@ exports[`getView Happy path with default query params and no data from endpoints
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/attitudes-thinking-and-behaviour/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/attitudes-thinking-and-behaviour/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1716,9 +1720,11 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/attitudes-thinking-and-behaviour/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/attitudes-thinking-and-behaviour/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     

--- a/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
+++ b/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
@@ -501,9 +501,11 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <div class="govuk-grid-column-three-quarters">
         
           <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/children-families-and-communities/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/children-families-and-communities/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1445,9 +1447,11 @@ exports[`getView Happy path with default query params and no data from endpoints
     <div class="govuk-grid-column-three-quarters">
         
           <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/children-families-and-communities/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/children-families-and-communities/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1887,9 +1891,11 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <div class="govuk-grid-column-three-quarters">
         
           <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/children-families-and-communities/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/children-families-and-communities/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     

--- a/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
+++ b/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
@@ -501,9 +501,11 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <div class="govuk-grid-column-three-quarters">
         
           <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/drugs-and-alcohol/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/drugs-and-alcohol/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1445,9 +1447,11 @@ exports[`getView Happy path with default query params and no data from endpoints
     <div class="govuk-grid-column-three-quarters">
         
           <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/drugs-and-alcohol/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/drugs-and-alcohol/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1887,9 +1891,11 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <div class="govuk-grid-column-three-quarters">
         
           <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/drugs-and-alcohol/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/drugs-and-alcohol/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     

--- a/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
+++ b/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
@@ -342,9 +342,11 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/education-skills-and-work/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/education-skills-and-work/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1352,9 +1354,11 @@ exports[`getView Happy path with default query params and no data from endpoints
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/education-skills-and-work/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/education-skills-and-work/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1809,9 +1813,11 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/education-skills-and-work/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/education-skills-and-work/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     

--- a/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
+++ b/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
@@ -338,9 +338,11 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/finance-and-id/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/finance-and-id/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1502,9 +1504,11 @@ exports[`getView Happy path with default query params and no data from endpoints
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/finance-and-id/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/finance-and-id/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -2001,9 +2005,11 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/finance-and-id/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/finance-and-id/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     

--- a/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
+++ b/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
@@ -330,9 +330,11 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/health-status/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/health-status/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1274,9 +1276,11 @@ exports[`getView Happy path with default query params and no data from endpoints
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/health-status/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/health-status/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     
@@ -1716,9 +1720,11 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <div class="govuk-grid-column-three-quarters">
       
         <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/health-status/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/health-status/start/?prisonerNumber=A1234DY">Add a support need</a>
+       
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     

--- a/server/routes/support-needs/index.ts
+++ b/server/routes/support-needs/index.ts
@@ -9,11 +9,32 @@ export default (router: Router, services: Services) => {
     services.prisonerDetailsService,
   )
 
-  router.get('/support-needs/:pathway/start', [supportNeedsController.startForm])
-  router.get('/support-needs/:pathway', [supportNeedsController.getSupportNeeds])
-  router.post('/support-needs/:pathway', [supportNeedsController.submitSupportNeeds])
-  router.get('/support-needs/:pathway/status/:uuid', [supportNeedsController.getSupportNeedsStatus])
-  router.post('/support-needs/:pathway/status/:uuid', [supportNeedsController.submitSupportNeedsStatus])
-  router.get('/support-needs/:pathway/check-answers', [supportNeedsController.getCheckAnswers])
-  router.post('/support-needs/:pathway/complete', [supportNeedsController.finaliseSupportNeeds])
+  router.get('/support-needs/:pathway/start', [
+    supportNeedsController.checkLegacyProfile,
+    supportNeedsController.startForm,
+  ])
+  router.get('/support-needs/:pathway', [
+    supportNeedsController.checkLegacyProfile,
+    supportNeedsController.getSupportNeeds,
+  ])
+  router.post('/support-needs/:pathway', [
+    supportNeedsController.checkLegacyProfile,
+    supportNeedsController.submitSupportNeeds,
+  ])
+  router.get('/support-needs/:pathway/status/:uuid', [
+    supportNeedsController.checkLegacyProfile,
+    supportNeedsController.getSupportNeedsStatus,
+  ])
+  router.post('/support-needs/:pathway/status/:uuid', [
+    supportNeedsController.checkLegacyProfile,
+    supportNeedsController.submitSupportNeedsStatus,
+  ])
+  router.get('/support-needs/:pathway/check-answers', [
+    supportNeedsController.checkLegacyProfile,
+    supportNeedsController.getCheckAnswers,
+  ])
+  router.post('/support-needs/:pathway/complete', [
+    supportNeedsController.checkLegacyProfile,
+    supportNeedsController.finaliseSupportNeeds,
+  ])
 }

--- a/server/routes/support-needs/supportNeedsController.test.ts
+++ b/server/routes/support-needs/supportNeedsController.test.ts
@@ -20,7 +20,7 @@ const { supportNeedStateService, rpService } = mockedServices as Services
 beforeEach(() => {
   configHelper(config)
 
-  app = appWithAllRoutes({})
+  app = appWithAllRoutes({ production: false })
 
   FeatureFlags.getInstance = jest.fn().mockReturnValue(featureFlags)
   stubFeatureFlagToTrue(featureFlags, ['supportNeeds'])
@@ -34,6 +34,89 @@ afterEach(() => {
 })
 
 describe('SupportNeedsController', () => {
+  describe('checkLegacyProfile', () => {
+    describe('when a profile is a legacy profile', () => {
+      beforeEach(() => {
+        stubPrisonerDetails(rpService, null, null, true)
+      })
+
+      const legacyErrorText = 'Unable to access support needs for a legacy profile'
+
+      it('should throw an error for the start route', async () => {
+        await request(app)
+          .get('/support-needs/accommodation/start/?prisonerNumber=A1234DY')
+          .expect(500)
+          .then(res => {
+            expect(res.text).toContain(legacyErrorText)
+          })
+      })
+
+      it('should throw an error for the get support needs route', async () => {
+        await request(app)
+          .get('/support-needs/accommodation/?prisonerNumber=A1234DY')
+          .expect(500)
+          .then(res => {
+            expect(res.text).toContain(legacyErrorText)
+          })
+      })
+
+      it('should throw an error for the submit support needs route', async () => {
+        await request(app)
+          .post('/support-needs/accommodation')
+          .send({
+            prisonerNumber: 'A1234DY',
+          })
+          .expect(500)
+          .then(res => {
+            expect(res.text).toContain(legacyErrorText)
+          })
+      })
+
+      it('should throw an error for the get support needs status route', async () => {
+        await request(app)
+          .get('/support-needs/accommodation/status/need-uuid/?prisonerNumber=A1234DY')
+          .expect(500)
+          .then(res => {
+            expect(res.text).toContain(legacyErrorText)
+          })
+      })
+
+      it('should throw an error for the submit support needs status route', async () => {
+        await request(app)
+          .post('/support-needs/accommodation/status/need-uuid')
+          .send({
+            prisonerNumber: 'A1234DY',
+          })
+          .expect(500)
+          .then(res => {
+            expect(res.text).toContain(legacyErrorText)
+          })
+      })
+
+      it('should throw an error for the check answers route', async () => {
+        await request(app)
+          .get('/support-needs/accommodation/check-answers/?prisonerNumber=A1234DY')
+          .expect(500)
+          .then(res => {
+            expect(res.text).toContain(legacyErrorText)
+          })
+      })
+
+      it('should throw an error for finalise support needs route', async () => {
+        await request(app)
+          .post('/support-needs/accommodation/complete')
+          .send({
+            _csrf: 'xjM2bce6',
+            prisonerNumber: 'A8731DY',
+          })
+          .expect(500)
+          .then(res => {
+            expect(res.text).toContain(legacyErrorText)
+          })
+      })
+    })
+  })
+
   describe('resetSupportNeedsCache', () => {
     it('should throw an error if pathway is invalid', async () => {
       await request(app).get('/support-needs/invalid-pathway/start/?prisonerNumber=A1234DY').expect(500)

--- a/server/routes/support-needs/supportNeedsController.ts
+++ b/server/routes/support-needs/supportNeedsController.ts
@@ -16,12 +16,24 @@ export default class SupportNeedsController {
     // no op
   }
 
+  checkLegacyProfile: RequestHandler = async (req, res, next): Promise<void> => {
+    req.prisonerData = req.body.prisonerNumber
+      ? await this.prisonerDetailsService.loadPrisonerDetailsFromBody(req, res, false)
+      : await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, false)
+
+    if (req.prisonerData.supportNeedsLegacyProfile) {
+      next(new Error('Unable to access support needs for a legacy profile'))
+    } else {
+      next()
+    }
+  }
+
   startForm: RequestHandler = async (req, res, next): Promise<void> => {
     try {
       const { pathway } = req.params
       await validatePathwaySupportNeeds(pathway)
       const pathwayEnum = getEnumByURL(pathway)
-      const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, false)
+      const { prisonerData } = req
       const { prisonerNumber } = prisonerData.personalDetails
       const stateKey = {
         prisonerNumber,
@@ -70,7 +82,7 @@ export default class SupportNeedsController {
     try {
       const { pathway } = req.params
       await validatePathwaySupportNeeds(pathway)
-      const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, false)
+      const { prisonerData } = req
       const { prisonerNumber } = prisonerData.personalDetails
       const pathwayEnum = getEnumByURL(pathway)
 
@@ -95,7 +107,7 @@ export default class SupportNeedsController {
       const { pathway } = req.params
       await validatePathwaySupportNeeds(pathway)
       const pathwayEnum = getEnumByURL(pathway)
-      const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromBody(req, res, false)
+      const { prisonerData } = req
       const { prisonerNumber } = prisonerData.personalDetails
 
       const stateKey = {
@@ -130,7 +142,7 @@ export default class SupportNeedsController {
       const { pathway, uuid } = req.params
       await validatePathwaySupportNeeds(pathway)
       const pathwayEnum = getEnumByURL(pathway)
-      const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, false)
+      const { prisonerData } = req
       const { prisonerNumber } = prisonerData.personalDetails
 
       const stateKey = {
@@ -158,7 +170,7 @@ export default class SupportNeedsController {
       const { pathway, uuid } = req.params
       await validatePathwaySupportNeeds(pathway)
       const pathwayEnum = getEnumByURL(pathway)
-      const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromBody(req, res, false)
+      const { prisonerData } = req
       const { prisonerNumber } = prisonerData.personalDetails
 
       const stateKey = {
@@ -217,7 +229,7 @@ export default class SupportNeedsController {
       const { pathway } = req.params
       await validatePathwaySupportNeeds(pathway)
       const pathwayEnum = getEnumByURL(pathway)
-      const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, false)
+      const { prisonerData } = req
       const { prisonerNumber } = prisonerData.personalDetails
 
       const stateKey = {
@@ -240,7 +252,7 @@ export default class SupportNeedsController {
   finaliseSupportNeeds: RequestHandler = async (req, res, next): Promise<void> => {
     try {
       const { pathway } = req.params
-      const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromBody(req, res, false)
+      const { prisonerData } = req
       const { prisonerNumber } = prisonerData.personalDetails
       await validatePathwaySupportNeeds(pathway)
       const pathwayEnum = getEnumByURL(pathway)

--- a/server/routes/testutils/testUtils.ts
+++ b/server/routes/testutils/testUtils.ts
@@ -5,7 +5,12 @@ import RpService from '../../services/rpService'
 import { PrisonersList } from '../../data/model/prisoners'
 import FeatureFlags from '../../featureFlag'
 
-export function stubPrisonerDetails(rpService: RpService, releaseDate: string = null, dateOfBirth: string = null) {
+export function stubPrisonerDetails(
+  rpService: RpService,
+  releaseDate: string = null,
+  dateOfBirth: string = null,
+  supportNeedsLegacyProfile: boolean = false,
+) {
   jest.spyOn(rpService, 'getPrisonerDetails').mockResolvedValue({
     personalDetails: {
       prisonerNumber: 'A1234DY',
@@ -16,6 +21,7 @@ export function stubPrisonerDetails(rpService: RpService, releaseDate: string = 
       releaseDate,
       dateOfBirth,
     },
+    supportNeedsLegacyProfile,
     pathways: [
       {
         pathway: 'ACCOMMODATION',

--- a/server/views/partials/supportNeedsSummary.njk
+++ b/server/views/partials/supportNeedsSummary.njk
@@ -1,7 +1,15 @@
 <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
-   <header class="app-summary-card__header">
+  <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
-    <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/{{ pathway | getUrlFromName }}/start/?prisonerNumber={{ prisonerData.personalDetails.prisonerNumber }}">Add a support need</a>
+       {% if prisonerData.supportNeedsLegacyProfile %}
+           <div class="govuk-summary-card__actions">
+               <p class="govuk-body-m govuk-!-margin-bottom-0">
+                   New support needs cannot be added for this person.&nbsp;<a class="govuk-link govuk-link--no-visited-state" href="#">Find out why</a>.
+               </p>
+           </div>
+       {% else %}
+           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/{{ pathway | getUrlFromName }}/start/?prisonerNumber={{ prisonerData.personalDetails.prisonerNumber }}">Add a support need</a>
+       {% endif %}
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
     {% if pathwaySupportNeedsSummary.supportNeedsSet %}


### PR DESCRIPTION
* removed the "add support need" links for legacy profiles
* blocked access to support need routes for legacy profiles