### PR TITLE
RSP-1863: Added previous updates to update support needs page

### DIFF
--- a/localstack/config.json
+++ b/localstack/config.json
@@ -22,5 +22,8 @@
   "whatsNew": {
     "enabled": true,
     "version": "20250114"
+  },
+  "supportNeeds": {
+    "releaseDate": "2025-03-18"
   }
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -72,6 +72,7 @@ export type PathwayStatus = {
 export type ConfigFile = {
   reports: Reports
   whatsNew?: WhatsNewConfig
+  supportNeeds?: SupportNeedsConfig
 }
 
 export type Reports = {
@@ -82,6 +83,10 @@ export type Reports = {
 export type WhatsNewConfig = {
   enabled: boolean
   version: string
+}
+
+export type SupportNeedsConfig = {
+  releaseDate: string
 }
 
 export type Pathway = keyof typeof PATHWAY_DICTIONARY

--- a/server/routes/configHelperTest.ts
+++ b/server/routes/configHelperTest.ts
@@ -26,6 +26,9 @@ export const defaultTestConfig: ConfigFile = {
     enabled: false,
     version: '1',
   },
+  supportNeeds: {
+    releaseDate: '2025-03-18',
+  },
 }
 
 export function configHelper(config: jest.Mocked<Config>, getConfigReturnValue: ConfigFile = defaultTestConfig) {

--- a/server/routes/support-need-update/__snapshots__/supportNeedUpdateController.test.ts.snap
+++ b/server/routes/support-need-update/__snapshots__/supportNeedUpdateController.test.ts.snap
@@ -149,8 +149,97 @@ exports[`SupportNeedUpdateController getSupportNeedUpdateForm happy path 1`] = `
       <h1 class="govuk-heading-l">
         Support need title
       </h1>
-    </div>
-    <div class="govuk-grid-column-three-quarters">
+
+      <details class="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            See previous updates
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text govuk-!-font-weight-regular">
+              <span class="govuk-visually-hidden">Warning</span>
+              Some updates may not be linked to this support need as they were created before support needs were added to PSfR.
+              Check the Accommodation tab for updates from before 18 March 2025.
+            </strong>
+          </div>
+          
+            <h3>12 December 2024</h3>
+            <div>
+              
+                <p class="govuk-body">
+                  <strong>Status set to: </strong>
+                  
+                  <span class="govuk-tag govuk-tag--green">Support met</span>
+                </p>
+              
+              
+                <p class="govuk-body">
+                  <strong>Responsible staff set to: </strong>
+                  
+                    <strong class="govuk-tag govuk-tag--blue">Prison resettlement team</strong>
+                  
+                  
+                </p>
+              
+              <p class="govuk-body show-line-breaks">This is some update text 3</p>
+              <p class="govuk-caption-m">Updated by A user</p>
+              <hr class="govuk-section-break govuk-section-break--visible">
+            </div>
+          
+            <h3>11 December 2024</h3>
+            <div>
+              
+                <p class="govuk-body">
+                  <strong>Status set to: </strong>
+                  
+                  <span class="govuk-tag govuk-tag--yellow">Support in progress</span>
+                </p>
+              
+              
+                <p class="govuk-body">
+                  <strong>Responsible staff set to: </strong>
+                  
+                  
+                    <strong class="govuk-tag govuk-tag--blue">Community probation staff</strong>
+                  
+                </p>
+              
+              <p class="govuk-body show-line-breaks">This is some update text 2</p>
+              <p class="govuk-caption-m">Updated by B user</p>
+              <hr class="govuk-section-break govuk-section-break--visible">
+            </div>
+          
+            <h3>11 December 2024</h3>
+            <div>
+              
+                <p class="govuk-body">
+                  <strong>Status set to: </strong>
+                  
+                  <span class="govuk-tag govuk-tag--orange">Support not started</span>
+                </p>
+              
+              
+                <p class="govuk-body">
+                  <strong>Responsible staff set to: </strong>
+                  
+                    <strong class="govuk-tag govuk-tag--blue">Prison resettlement team</strong>
+                  
+                  
+                    <strong class="govuk-tag govuk-tag--blue">Community probation staff</strong>
+                  
+                </p>
+              
+              <p class="govuk-body show-line-breaks">This is some update text 1</p>
+              <p class="govuk-caption-m">Updated by A user</p>
+              <hr class="govuk-section-break govuk-section-break--visible">
+            </div>
+          
+        </div>
+      </details>
+
       <form action="/support-needs/accommodation/update/23" method="post">
         <div class="govuk-form-group">
           <div class="govuk-form-group">
@@ -182,6 +271,7 @@ exports[`SupportNeedUpdateController getSupportNeedUpdateForm happy path 1`] = `
             <fieldset class="govuk-fieldset">
               <legend class="govuk-fieldset__legend">
                 <h2 class="govuk-fieldset__heading">Who is responsible for this support need?</h2>
+                <p class="govuk-caption-m">Select all that apply</p>
               </legend>
               <div class="govuk-checkboxes" data-module="govuk-checkboxes" data-govuk-checkboxes-init>
                 <div class="govuk-checkboxes__item">

--- a/server/routes/support-need-update/supportNeedUpdateController.ts
+++ b/server/routes/support-need-update/supportNeedUpdateController.ts
@@ -32,6 +32,7 @@ export default class SupportNeedUpdateController {
         existingPrisonerNeed,
         pathwayName,
         prisonerNeedId,
+        req.config.supportNeeds.releaseDate,
       )
 
       res.render('pages/update-support-need', { ...supportNeedUpdateView.renderArgs })

--- a/server/routes/support-need-update/supportNeedUpdateView.ts
+++ b/server/routes/support-need-update/supportNeedUpdateView.ts
@@ -8,6 +8,7 @@ export default class SupportNeedUpdateView implements View {
     private readonly existingPrisonerNeed: PrisonerSupportNeedDetails,
     private readonly pathway: string,
     private readonly prisonerNeedId: string,
+    private readonly releaseDate: string,
     private readonly errors: ErrorMessage[] = [],
   ) {
     // no op
@@ -18,6 +19,7 @@ export default class SupportNeedUpdateView implements View {
     existingPrisonerNeed: PrisonerSupportNeedDetails
     pathway: string
     prisonerNeedId: string
+    releaseDate: string
     errors: ErrorMessage[]
   } {
     return {
@@ -25,6 +27,7 @@ export default class SupportNeedUpdateView implements View {
       existingPrisonerNeed: this.existingPrisonerNeed,
       pathway: this.pathway,
       prisonerNeedId: this.prisonerNeedId,
+      releaseDate: this.releaseDate,
       errors: this.errors.length !== 0 ? this.errors : null,
     }
   }

--- a/server/views/pages/update-support-need.njk
+++ b/server/views/pages/update-support-need.njk
@@ -70,7 +70,7 @@
             <strong class="govuk-warning-text__text govuk-!-font-weight-regular">
               <span class="govuk-visually-hidden">Warning</span>
               Some updates may not be linked to this support need as they were created before support needs were added to PSfR.
-              Check the {{ pathway }} tab for updates from before 18 March 2025.
+              Check the {{ pathway }} tab for updates from before {{ releaseDate | formatDate('long') }}.
             </strong>
           </div>
           {% for update in existingPrisonerNeed.previousUpdates %}

--- a/server/views/pages/update-support-need.njk
+++ b/server/views/pages/update-support-need.njk
@@ -57,8 +57,51 @@
       <h1 class="govuk-heading-l">
         {{ existingPrisonerNeed.title }}
       </h1>
-    </div>
-    <div class="govuk-grid-column-three-quarters">
+
+      <details class="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            See previous updates
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text govuk-!-font-weight-regular">
+              <span class="govuk-visually-hidden">Warning</span>
+              Some updates may not be linked to this support need as they were created before support needs were added to PSfR.
+              Check the {{ pathway }} tab for updates from before 18 March 2025.
+            </strong>
+          </div>
+          {% for update in existingPrisonerNeed.previousUpdates %}
+            <h3>{{ update.createdAt | formatDate('long') }}</h3>
+            <div>
+              {% if update.status %}
+                <p class="govuk-body">
+                  <strong>Status set to: </strong>
+                  {% set tagColour = "govuk-tag--" + (update.status | getSupportNeedsColour) %}
+                  <span class="govuk-tag {{ tagColour }}">{{ update.status | getSupportNeedsStatus }}</span>
+                </p>
+              {% endif %}
+              {% if update.isPrisonResponsible or update.isProbationResponsible %}
+                <p class="govuk-body">
+                  <strong>Responsible staff set to: </strong>
+                  {% if update.isPrisonResponsible %}
+                    <strong class="govuk-tag govuk-tag--blue">Prison resettlement team</strong>
+                  {% endif %}
+                  {% if update.isProbationResponsible %}
+                    <strong class="govuk-tag govuk-tag--blue">Community probation staff</strong>
+                  {% endif %}
+                </p>
+              {% endif %}
+              <p class="govuk-body show-line-breaks">{{ update.text }}</p>
+              <p class="govuk-caption-m">Updated by {{ update.createdBy }}</p>
+              <hr class="govuk-section-break govuk-section-break--visible">
+            </div>
+          {% endfor %}
+        </div>
+      </details>
+
       <form action="/support-needs/{{ pathway | getUrlFromName }}/update/{{ prisonerNeedId }}" method="post">
         <div class="govuk-form-group">
           <div class="govuk-form-group">
@@ -90,6 +133,7 @@
             <fieldset class="govuk-fieldset">
               <legend class="govuk-fieldset__legend">
                 <h2 class="govuk-fieldset__heading">Who is responsible for this support need?</h2>
+                <p class="govuk-caption-m">Select all that apply</p>
               </legend>
               <div class="govuk-checkboxes" data-module="govuk-checkboxes" data-govuk-checkboxes-init>
                 <div class="govuk-checkboxes__item">


### PR DESCRIPTION
When editing an existing support need, you can now see all previous updates via a [details component](https://design-system.service.gov.uk/components/details/) at the top of the page.

There is also a [warning text component](https://design-system.service.gov.uk/components/warning-text/) which mentions the release date for support needs - this is pulled from config.