### PR TITLE
RSP-1866: Set 'Last Updated' link on prisoner search page to 'Support needs statuses' panel

### DIFF
--- a/server/routes/staffDashboard/__snapshots__/staffDashboardController.test.ts.snap
+++ b/server/routes/staffDashboard/__snapshots__/staffDashboardController.test.ts.snap
@@ -1052,7 +1052,7 @@ exports[`getView Happy path with default query params with supportNeeds enabled,
     
       <td class="govuk-table__cell">
         <span id="lastUpdated">
-          <a href="/prisoner-overview/?prisonerNumber=G9808UX#status">
+          <a href="/prisoner-overview/?prisonerNumber=G9808UX#support-needs">
             
           </a>
         </span>
@@ -1742,7 +1742,7 @@ exports[`getView Happy path with default query params without tabs nav 1`] = `
     
       <td class="govuk-table__cell">
         <span id="lastUpdated">
-          <a href="/prisoner-overview/?prisonerNumber=G9808UX#status">
+          <a href="/prisoner-overview/?prisonerNumber=G9808UX#support-needs">
             
           </a>
         </span>

--- a/server/views/macros/prisoners-table.njk
+++ b/server/views/macros/prisoners-table.njk
@@ -206,7 +206,7 @@
     {% if supportNeedsEnabled %}
       <td class="govuk-table__cell">
         <span id="lastUpdated">
-          <a href="/prisoner-overview/?prisonerNumber={{ prisonerNumber }}#status">
+          <a href="/prisoner-overview/?prisonerNumber={{ prisonerNumber }}#support-needs">
             {{ lastUpdatedDate | formatDate }}
           </a>
         </span>


### PR DESCRIPTION
When supportNeeds is enabled, the 'Last Updated' link in the prisoner table now links to the 'Support needs statuses' panel on the prisoner overview page, instead of to the top of the page.