### PR TITLE
RSP-1911: Remove excess whitespace at the top of case notes.

### DIFF
--- a/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
+++ b/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
@@ -433,29 +433,43 @@ exports[`getView Happy path - ensure support need for legacy profile renders cor
           <hr>
           
             
-            <div class="case-note">
-              <h3>Accommodation</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Accommodation</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           
@@ -1454,29 +1468,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Accommodation</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Accommodation</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           
@@ -2955,29 +2983,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Accommodation</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Accommodation</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           

--- a/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
+++ b/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
@@ -609,29 +609,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Attitudes, thinking and behaviour</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Attitudes, thinking and behaviour</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           
@@ -1999,29 +2013,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Attitudes, thinking and behaviour</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Attitudes, thinking and behaviour</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           

--- a/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
+++ b/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
@@ -780,29 +780,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Children, families and communities</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Children, families and communities</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Children, families and communities</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Children, families and communities</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           
@@ -2170,29 +2184,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Children, families and communities</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Children, families and communities</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Children, families and communities</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Children, families and communities</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           

--- a/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
+++ b/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
@@ -780,29 +780,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Drugs and alcohol</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Drugs and alcohol</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Drugs and alcohol</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Drugs and alcohol</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           
@@ -2170,29 +2184,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Drugs and alcohol</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Drugs and alcohol</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Drugs and alcohol</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Drugs and alcohol</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           

--- a/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
+++ b/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
@@ -621,29 +621,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Education, skills and work</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Education, skills and work</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           
@@ -2092,29 +2106,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Education, skills and work</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Education, skills and work</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           

--- a/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
+++ b/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
@@ -617,29 +617,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Finance and ID</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Finance and ID</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           
@@ -2183,29 +2197,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Finance and ID</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Finance and ID</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           

--- a/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
+++ b/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
@@ -609,29 +609,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Health</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Health</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           
@@ -1999,29 +2013,43 @@ It has a line break in</p>
           <hr>
           
             
-            <div class="case-note">
-              <h3>Health</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is a case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is a case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
             
-            <div class="case-note">
-              <h3>Health</h3>
-              <strong></strong>
-              <p class="show-line-breaks">
-                This is another case note
-              </p>
-              <span class="govuk-caption-m">Happened: 7 September 2024</span>
-              <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
-              <br>
-            </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+  
+      <p class="show-line-breaks">
+          This is another case note
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 7 September 2024</span>
+  <span class="govuk-caption-m">Created: 7 September 2024 by A User</span>
+</div>
             <hr>
             
           

--- a/server/routes/prisoner-overview/__snapshots__/prisonerOverviewController.test.ts.snap
+++ b/server/routes/prisoner-overview/__snapshots__/prisonerOverviewController.test.ts.snap
@@ -489,179 +489,179 @@ exports[`prisonerOverview happy path with default query parameters 1`] = `
               
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Finance and ID</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Support declined.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        test
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 22 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Support declined.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Accommodation</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Support required.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        Updating the status to support required.
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 22 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+    <strong>Resettlement status set to: Support required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          Updating the status to support required.
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Health</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Support not required.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        redirecting test
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+    <strong>Resettlement status set to: Support not required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirecting test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Finance and ID</h3>
-                    
-                    
-                      <strong>Resettlement status set to: In progress.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        redirected to pathway page
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirected to pathway page
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Education, skills and work</h3>
-                    
-                    
-                      <strong>Resettlement status set to: In progress.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        testing redirect to individual pathway...
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect to individual pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Finance and ID</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Done.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        testing redirect form to pathway...
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect form to pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Attitudes, thinking and behaviour</h3>
-                    
-                    
-                      <strong>Resettlement status set to: In progress.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        test update redirect
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test update redirect
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Attitudes, thinking and behaviour</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Done.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        form submit redirect to pathway
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          form submit redirect to pathway
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                 
@@ -1707,179 +1707,179 @@ exports[`prisonerOverview should display responsible staff data when supportNeed
               
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Finance and ID</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Support declined.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        test
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 22 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Support declined.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Accommodation</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Support required.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        Updating the status to support required.
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 22 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+    <strong>Resettlement status set to: Support required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          Updating the status to support required.
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Health</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Support not required.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        redirecting test
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+    <strong>Resettlement status set to: Support not required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirecting test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Finance and ID</h3>
-                    
-                    
-                      <strong>Resettlement status set to: In progress.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        redirected to pathway page
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirected to pathway page
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Education, skills and work</h3>
-                    
-                    
-                      <strong>Resettlement status set to: In progress.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        testing redirect to individual pathway...
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect to individual pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Finance and ID</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Done.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        testing redirect form to pathway...
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect form to pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Attitudes, thinking and behaviour</h3>
-                    
-                    
-                      <strong>Resettlement status set to: In progress.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        test update redirect
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test update redirect
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Attitudes, thinking and behaviour</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Done.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        form submit redirect to pathway
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          form submit redirect to pathway
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                 
@@ -2754,179 +2754,179 @@ exports[`prisonerOverview should render the prisoner overview page with correct 
               
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Finance and ID</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Support declined.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        test
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 22 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Support declined.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Accommodation</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Support required.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        Updating the status to support required.
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 22 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+    <strong>Resettlement status set to: Support required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          Updating the status to support required.
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Health</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Support not required.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        redirecting test
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+    <strong>Resettlement status set to: Support not required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirecting test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Finance and ID</h3>
-                    
-                    
-                      <strong>Resettlement status set to: In progress.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        redirected to pathway page
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirected to pathway page
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Education, skills and work</h3>
-                    
-                    
-                      <strong>Resettlement status set to: In progress.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        testing redirect to individual pathway...
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect to individual pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Finance and ID</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Done.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        testing redirect form to pathway...
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect form to pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Attitudes, thinking and behaviour</h3>
-                    
-                    
-                      <strong>Resettlement status set to: In progress.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        test update redirect
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test update redirect
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                   
-                  <div class="case-note">
-                    
-                    
-                    
-                    
-                      <h3>Attitudes, thinking and behaviour</h3>
-                    
-                    
-                      <strong>Resettlement status set to: Done.</strong>
-                    
-                    <p class="show-line-breaks">
-                      
-                        form submit redirect to pathway
-                      
-                    </p>
-                    <span class="govuk-caption-m">Happened: 19 April 2024</span>
-                    <span
-                        class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
-                  </div>
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          form submit redirect to pathway
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
                   <hr>
                 
                 

--- a/server/views/pages/overview.njk
+++ b/server/views/pages/overview.njk
@@ -283,28 +283,7 @@
               <hr>
               {% if not caseNotes.error %}
                 {% for notes in caseNotes.content %}
-                  {% set currentPathway = notes.pathway | getEnumValue %}
-                  <div class="case-note">
-                    {% set caseNoteTitle = notes.text | getCaseNoteTitle(currentPathway.name) %}
-                    {% set caseNoteIntro = notes.text | getCaseNotesIntro %}
-                    {% set resetProfileCaseNote = notes.text | getResetReason %}
-                    {% if caseNoteTitle %}
-                      <h3>{{ caseNoteTitle }}</h3>
-                    {% endif %}
-                    {% if caseNoteIntro %}
-                      <strong>{{ caseNoteIntro }}</strong>
-                    {% endif %}
-                    <p class="show-line-breaks">
-                      {% if resetProfileCaseNote %}
-                        <strong>Reason for reset: </strong>{{ resetProfileCaseNote }}
-                        {% else %}
-                        {{ notes.text | getCaseNotesText }}
-                      {% endif %}
-                    </p>
-                    <span class="govuk-caption-m">Happened: {{ notes.occurenceDateTime | formatDate('long') }}</span>
-                    <span
-                        class="govuk-caption-m">Created: {{ notes.creationDateTime | formatDate('long') }} by {{ notes.createdBy }}</span>
-                  </div>
+                  {% include "../partials/caseNote.njk" %}
                   <hr>
                 {% else %}
                   <p>No case notes found</p>

--- a/server/views/partials/caseNote.njk
+++ b/server/views/partials/caseNote.njk
@@ -1,0 +1,24 @@
+{% set currentPathway = notes.pathway | getEnumValue %}
+{% set caseNoteTitle = notes.text | getCaseNoteTitle(currentPathway.name) %}
+{% set caseNoteIntro = notes.text | getCaseNotesIntro %}
+{% set resetProfileCaseNote = notes.text | getResetReason %}
+
+<div class="case-note">
+  {% if caseNoteTitle %}
+    <h3>{{ caseNoteTitle }}</h3>
+  {% endif %}
+  {% if caseNoteIntro %}
+    <strong>{{ caseNoteIntro }}</strong>
+  {% endif %}
+  {% if resetProfileCaseNote %}
+      <p class="show-line-breaks">
+          <strong>Reason for reset: </strong>{{ resetProfileCaseNote }}
+      </p>
+  {% else %}
+      <p class="show-line-breaks">
+          {{ notes.text | getCaseNotesText }}
+      </p>
+  {% endif %}
+  <span class="govuk-caption-m">Happened: {{ notes.occurenceDateTime | formatDate('long') }}</span>
+  <span class="govuk-caption-m">Created: {{ notes.creationDateTime | formatDate('long') }} by {{ notes.createdBy }}</span>
+</div>

--- a/server/views/partials/caseNotes.njk
+++ b/server/views/partials/caseNotes.njk
@@ -32,18 +32,8 @@
       <div class="govuk-grid-row govuk-!-padding-top-8">
         <div class="govuk-grid-column-full" id="case-notes-container">
           <hr>
-          {% for caseNote in caseNotesData.results.content %}
-            {% set caseNotePathway = caseNote.pathway | getEnumValue %}
-            <div class="case-note">
-              <h3>{{ caseNotePathway.name }}</h3>
-              <strong>{{ caseNote.text | getCaseNotesIntro }}</strong>
-              <p class="show-line-breaks">
-                {{ caseNote.text | getCaseNotesText }}
-              </p>
-              <span class="govuk-caption-m">Happened: {{ caseNote.occurenceDateTime | formatDate('long') }}</span>
-              <span class="govuk-caption-m">Created: {{ caseNote.creationDateTime | formatDate('long')  }} by {{caseNote.createdBy}}</span>
-              <br>
-            </div>
+          {% for notes in caseNotesData.results.content %}
+            {% include "./caseNote.njk" %}
             <hr>
             {% else %}
               <p>No case notes found</p>


### PR DESCRIPTION
Remove excess whitespace from the top of case notes on the prisoner overview page, by refactoring the code to remove if/else clause from within the 'show-line-breaks' tag.

Also factored out the case note code into a separate caseNote.njk file, so it can be used by both the prisoner overview and the pathways pages instead of duplicating code. 