### PR TITLE
RSP-1967 Add error page for support need update not found

### DIFF
--- a/server/routes/support-needs/__snapshots__/supportNeedsController.test.ts.snap
+++ b/server/routes/support-needs/__snapshots__/supportNeedsController.test.ts.snap
@@ -5,7 +5,7 @@ exports[`SupportNeedsController getCheckAnswers should render the check your ans
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - accommodation Support Need status
+    <title>Prepare someone for release - Accommodation support needs - Check your answers
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -226,7 +226,7 @@ exports[`SupportNeedsController getSupportNeeds should render the support needs 
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - accommodation Support Needs
+    <title>Prepare someone for release - Accommodation support Needs
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -671,7 +671,7 @@ exports[`SupportNeedsController getSupportNeeds should render the support needs 
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - accommodation Support Needs
+    <title>Prepare someone for release - Accommodation support Needs
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -1015,7 +1015,7 @@ exports[`SupportNeedsController getSupportNeedsStatus with cached answers should
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - accommodation Support needs status
+    <title>Prepare someone for release - Accommodation support needs status
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -1227,7 +1227,7 @@ exports[`SupportNeedsController getSupportNeedsStatus with cached answers should
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - accommodation Support needs status
+    <title>Prepare someone for release - Accommodation support needs status
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -1439,7 +1439,7 @@ exports[`SupportNeedsController getSupportNeedsStatus with cached other support 
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - accommodation Support needs status
+    <title>Prepare someone for release - Accommodation support needs status
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -1651,7 +1651,7 @@ exports[`SupportNeedsController getSupportNeedsStatus with cached other support 
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - accommodation Support needs status
+    <title>Prepare someone for release - Accommodation support needs status
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -1863,7 +1863,7 @@ exports[`SupportNeedsController getSupportNeedsStatus without any cached answers
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - accommodation Support needs status
+    <title>Prepare someone for release - Accommodation support needs status
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -1966,11 +1966,11 @@ exports[`SupportNeedsController getSupportNeedsStatus without any cached answers
     <div class="govuk-grid-column-three-quarters">
       <span class="govuk-caption-l">Accommodation support need</span>
       
-        <h1 class="govuk-heading-l">End a tenancy</h1>
+        <h1 class="govuk-heading-l">Mortgage support while in prison</h1>
       
     </div>
     <div class="govuk-grid-column-three-quarters">
-      <form action="/support-needs/accommodation/status/need-uuid" class="govuk-form" method="POST">
+      <form action="/support-needs/accommodation/status/need-uuid-is-selected" class="govuk-form" method="POST">
         <div class="govuk-form-group">
           <div class="govuk-form-group" id="status">
             <fieldset class="govuk-fieldset">
@@ -2032,7 +2032,7 @@ exports[`SupportNeedsController getSupportNeedsStatus without any cached answers
       <button class="ghost-button remove-support-need-button">Remove support need</button>
       <div class="confirm-remove-support-need" hidden>
         <div class="govuk-button-group">
-          <form action="/support-needs/accommodation/status/need-uuid/delete" method="post" novalidate>
+          <form action="/support-needs/accommodation/status/need-uuid-is-selected/delete" method="post" novalidate>
             <button class="govuk-button govuk-button--warning" type="submit" data-prevent-double-click="true">Confirm remove support need</button>
             <input type="hidden" name="prisonerNumber" value="A1234DY">
             <input type="hidden" name="edit" value="false">

--- a/server/routes/support-needs/__snapshots__/supportNeedsController.test.ts.snap
+++ b/server/routes/support-needs/__snapshots__/supportNeedsController.test.ts.snap
@@ -226,7 +226,7 @@ exports[`SupportNeedsController getSupportNeeds should render the support needs 
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - Accommodation support Needs
+    <title>Prepare someone for release - Accommodation support needs
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -671,7 +671,7 @@ exports[`SupportNeedsController getSupportNeeds should render the support needs 
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Prepare someone for release - Accommodation support Needs
+    <title>Prepare someone for release - Accommodation support needs
 </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">

--- a/server/routes/support-needs/supportNeedsController.test.ts
+++ b/server/routes/support-needs/supportNeedsController.test.ts
@@ -115,6 +115,16 @@ describe('SupportNeedsController', () => {
             expect(res.text).toContain(legacyErrorText)
           })
       })
+
+      it('should gracefully handle unexpected errors', async () => {
+        jest.spyOn(rpService, 'getPrisonerDetails').mockRejectedValue(new Error('Something went wrong'))
+        await request(app)
+          .get('/support-needs/accommodation/?prisonerNumber=A1234DY')
+          .expect(500)
+          .then(res => {
+            expect(res.text).toContain('Something went wrong')
+          })
+      })
     })
   })
 
@@ -1320,7 +1330,7 @@ describe('SupportNeedsController', () => {
             isPreSelected: false,
           },
           {
-            uuid: '8442e4b7-82b9-4127-b746-42a3f8d78cb8',
+            uuid: 'need-uuid-is-selected',
             supportNeedId: 3,
             existingPrisonerSupportNeedId: null,
             allowUserDesc: false,
@@ -1333,7 +1343,7 @@ describe('SupportNeedsController', () => {
             otherSupportNeedText: null,
             status: null,
             updateText: null,
-            isSelected: null,
+            isSelected: true,
             isPreSelected: false,
           },
           {
@@ -1556,12 +1566,16 @@ describe('SupportNeedsController', () => {
     })
 
     it('should throw an error if the uuid does not exist in cache', async () => {
-      await request(app).get('/support-needs/accommodation/status/invalid-uuid/?prisonerNumber=A1234DY').expect(500)
+      await request(app).get('/support-needs/accommodation/status/invalid-uuid/?prisonerNumber=A1234DY').expect(404)
+    })
+
+    it("should throw an error if the uuid exists in cache but isn't selected", async () => {
+      await request(app).get('/support-needs/accommodation/status/need-uuid/?prisonerNumber=A1234DY').expect(404)
     })
 
     it('should render the support needs status page', async () => {
       await request(app)
-        .get('/support-needs/accommodation/status/need-uuid/?prisonerNumber=A1234DY')
+        .get('/support-needs/accommodation/status/need-uuid-is-selected/?prisonerNumber=A1234DY')
         .expect(200)
         .expect(res => {
           expect(res.text).toMatchSnapshot()
@@ -1621,7 +1635,7 @@ describe('SupportNeedsController', () => {
     })
 
     it('should throw an error if the uuid does not exist in cache', async () => {
-      await request(app).get('/support-needs/accommodation/status/invalid-uuid/?prisonerNumber=A1234DY').expect(500)
+      await request(app).get('/support-needs/accommodation/status/invalid-uuid/?prisonerNumber=A1234DY').expect(404)
     })
 
     it('should render the support needs status page', async () => {
@@ -1678,7 +1692,7 @@ describe('SupportNeedsController', () => {
     })
 
     it('should throw an error if the uuid does not exist in cache', async () => {
-      await request(app).get('/support-needs/accommodation/status/invalid-uuid/?prisonerNumber=A1234DY').expect(500)
+      await request(app).get('/support-needs/accommodation/status/invalid-uuid/?prisonerNumber=A1234DY').expect(404)
     })
 
     it('should render the support needs status page', async () => {

--- a/server/routes/support-needs/supportNeedsController.ts
+++ b/server/routes/support-needs/supportNeedsController.ts
@@ -1,4 +1,5 @@
 import { RequestHandler } from 'express'
+import createError from 'http-errors'
 import { validatePathwaySupportNeeds, getEnumByURL } from '../../utils/utils'
 import { PrisonerSupportNeedsPost, SupportNeedCache } from '../../data/model/supportNeeds'
 import { SupportNeedStateService } from '../../data/supportNeedStateService'
@@ -17,14 +18,18 @@ export default class SupportNeedsController {
   }
 
   checkLegacyProfile: RequestHandler = async (req, res, next): Promise<void> => {
-    req.prisonerData = req.body.prisonerNumber
-      ? await this.prisonerDetailsService.loadPrisonerDetailsFromBody(req, res, false)
-      : await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, false)
+    try {
+      req.prisonerData = req.body.prisonerNumber
+        ? await this.prisonerDetailsService.loadPrisonerDetailsFromBody(req, res, false)
+        : await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, false)
 
-    if (req.prisonerData.supportNeedsLegacyProfile) {
-      next(new Error('Unable to access support needs for a legacy profile'))
-    } else {
-      next()
+      if (req.prisonerData.supportNeedsLegacyProfile) {
+        next(new Error('Unable to access support needs for a legacy profile'))
+      } else {
+        next()
+      }
+    } catch (err) {
+      next(err)
     }
   }
 
@@ -157,15 +162,19 @@ export default class SupportNeedsController {
 
       const currentCacheState = await this.supportNeedStateService.getSupportNeeds(stateKey)
 
-      // Validate supportNeed exists in cache
+      // Validate supportNeed exists in cache and is selected
       const supportNeed = currentCacheState.needs.find(need => need.uuid === uuid)
       if (!supportNeed) {
-        throw new Error('Support need not found')
+        return next(createError(404, `Need with UUID ${uuid} not found in cache`))
+      }
+      if (!supportNeed.isSelected) {
+        res.status(404)
+        return res.render('pages/support-needs-error', { pathway, prisonerData })
       }
 
-      res.render('pages/support-needs-status', { pathway, prisonerData, supportNeed, edit })
+      return res.render('pages/support-needs-status', { pathway, prisonerData, supportNeed, edit })
     } catch (err) {
-      next(err)
+      return next(err)
     }
   }
 

--- a/server/views/pages/support-needs-check-answers.njk
+++ b/server/views/pages/support-needs-check-answers.njk
@@ -1,5 +1,5 @@
 {% extends "../partials/layout.njk" %}
-{% set pageTitle = applicationName + " - " + pathway + " Support Need status" %}
+{% set pageTitle = applicationName + " - " + pathway | getNameFromUrl + " support needs - Check your answers" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block header %}

--- a/server/views/pages/support-needs-error.njk
+++ b/server/views/pages/support-needs-error.njk
@@ -1,0 +1,31 @@
+{% extends "../partials/layout.njk" %}
+{% set pageTitle = applicationName + " - " + pathway | getNameFromUrl + " support needs status" %}
+{% set mainClasses = "app-container govuk-body" %}
+{% set prisonerNumber = prisonerData.personalDetails.prisonerNumber %}
+{% block header %}
+  {% if feComponents.header %}
+    {{ feComponents.header | safe }}
+  {% else %}
+    {% include "../partials/header.njk" %}
+  {% endif %}
+  <div class="govuk-width-container">
+    {{ govukPhaseBanner({
+      tag: {
+      text: phaseName
+      },
+      html: feedbackText
+      }) }}
+  </div>
+{% endblock %}
+{% block content %}
+  <div class="govuk-grid-row govuk-!-padding-top-4 govuk-!-padding-bottom-4">
+    <div class="govuk-grid-column-three-quarters">
+      <span class="govuk-caption-l">{{ prisonerData.personalDetails.lastName }}, {{ prisonerData.personalDetails.firstName }} ({{ prisonerData.personalDetails.prisonerNumber }})</span>
+      <h1 class="govuk-heading-l">Support need deleted</h1>
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      <p>This support need is no longer set for this person in prison.</p>
+      <p><a class="govuk-link" href="/support-needs/{{ pathway }}?prisonerNumber={{ prisonerData.personalDetails.prisonerNumber }}">Add {{ pathway | getNameFromUrl }} support needs for this person.</a></p>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/pages/support-needs-status.njk
+++ b/server/views/pages/support-needs-status.njk
@@ -1,5 +1,5 @@
 {% extends "../partials/layout.njk" %}
-{% set pageTitle = applicationName + " - " + pathway + " Support needs status" %}
+{% set pageTitle = applicationName + " - " + pathway | getNameFromUrl + " support needs status" %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set prisonerNumber = prisonerData.personalDetails.prisonerNumber %}
 {% block header %}

--- a/server/views/pages/support-needs.njk
+++ b/server/views/pages/support-needs.njk
@@ -1,5 +1,5 @@
 {% extends "../partials/layout.njk" %}
-{% set pageTitle = applicationName + " - " + pathway + " Support Needs" %}
+{% set pageTitle = applicationName + " - " + pathway | getNameFromUrl + " support Needs" %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set prisonerNumber = prisonerData.personalDetails.prisonerNumber %}
 {% block header %}

--- a/server/views/pages/support-needs.njk
+++ b/server/views/pages/support-needs.njk
@@ -1,5 +1,5 @@
 {% extends "../partials/layout.njk" %}
-{% set pageTitle = applicationName + " - " + pathway | getNameFromUrl + " support Needs" %}
+{% set pageTitle = applicationName + " - " + pathway | getNameFromUrl + " support needs" %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set prisonerNumber = prisonerData.personalDetails.prisonerNumber %}
 {% block header %}


### PR DESCRIPTION
- Add custom error page if deleted support need is re-navigated to (also fixes RSP-1970)
- Send user to Something went wrong page if try to navigate to non-existent support need uuid
- Fix page titles for support needs pages
- Fix issue with missing prisonerNumber or unhandled error crashing node app in validation middleware