### PR TITLE
RSP-1988: Update support needs information links

### DIFF
--- a/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
+++ b/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
@@ -393,7 +393,6 @@ exports[`getView Happy path - ensure support need for legacy profile renders cor
     <h3 class="app-summary-card__title">
       Accommodation updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1311,7 +1310,6 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <h3 class="app-summary-card__title">
       Accommodation updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -2245,7 +2243,6 @@ exports[`getView Happy path with default query params and no data from endpoints
     <h3 class="app-summary-card__title">
       Accommodation updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -2826,7 +2823,6 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <h3 class="app-summary-card__title">
       Accommodation updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">

--- a/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
+++ b/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
@@ -341,7 +341,11 @@ exports[`getView Happy path - ensure support need for legacy profile renders cor
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">Support needs</h3>
        
-           <a class="govuk-summary-card__actions govuk-link govuk-link--no-visited-state" href="/support-needs/accommodation/start/?prisonerNumber=A1234DY">Add a support need</a>
+           <div class="govuk-summary-card__actions">
+               <p class="govuk-body-m govuk-!-margin-bottom-0">
+                   New support needs cannot be added for this person.&nbsp;<a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out why</a>.
+               </p>
+           </div>
        
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">

--- a/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
+++ b/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
@@ -392,7 +392,7 @@ exports[`getView Happy path - ensure support need for legacy profile renders cor
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Accommodation updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1310,7 +1310,7 @@ exports[`getView Happy path with default query params and data from endpoints 1`
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Accommodation updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -2244,7 +2244,7 @@ exports[`getView Happy path with default query params and no data from endpoints
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Accommodation updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -2825,7 +2825,7 @@ exports[`getView Happy path with specified query params and data from endpoints 
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Accommodation updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>

--- a/server/routes/accommodation/accommodationController.test.ts
+++ b/server/routes/accommodation/accommodationController.test.ts
@@ -169,6 +169,8 @@ describe('getView', () => {
   })
 
   it('Happy path - ensure support need for legacy profile renders correctly', async () => {
+    stubPrisonerDetails(rpService, null, null, true)
+
     const getCrsReferralsSpy = stubCrsReferrals(rpService, 'ACCOMMODATION')
     const getAccommodationSpy = stubAccommodation(rpService)
     const getAssessmentInformationSpy = stubAssessmentInformation(rpService)

--- a/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
+++ b/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
@@ -447,7 +447,7 @@ exports[`getView Happy path with default query params and data from endpoints 1`
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Attitudes, thinking and behaviour updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1306,7 +1306,7 @@ exports[`getView Happy path with default query params and no data from endpoints
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Attitudes, thinking and behaviour updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1851,7 +1851,7 @@ exports[`getView Happy path with specified query params and data from endpoints 
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Attitudes, thinking and behaviour updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>

--- a/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
+++ b/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
@@ -448,7 +448,6 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <h3 class="app-summary-card__title">
       Attitudes, thinking and behaviour updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1307,7 +1306,6 @@ exports[`getView Happy path with default query params and no data from endpoints
     <h3 class="app-summary-card__title">
       Attitudes, thinking and behaviour updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1852,7 +1850,6 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <h3 class="app-summary-card__title">
       Attitudes, thinking and behaviour updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">

--- a/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
+++ b/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
@@ -619,7 +619,6 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <h3 class="app-summary-card__title">
       Children, families and communities updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1478,7 +1477,6 @@ exports[`getView Happy path with default query params and no data from endpoints
     <h3 class="app-summary-card__title">
       Children, families and communities updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -2023,7 +2021,6 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <h3 class="app-summary-card__title">
       Children, families and communities updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">

--- a/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
+++ b/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
@@ -618,7 +618,7 @@ exports[`getView Happy path with default query params and data from endpoints 1`
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Children, families and communities updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1477,7 +1477,7 @@ exports[`getView Happy path with default query params and no data from endpoints
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Children, families and communities updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -2022,7 +2022,7 @@ exports[`getView Happy path with specified query params and data from endpoints 
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Children, families and communities updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>

--- a/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
+++ b/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
@@ -619,7 +619,6 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <h3 class="app-summary-card__title">
       Drugs and alcohol updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1478,7 +1477,6 @@ exports[`getView Happy path with default query params and no data from endpoints
     <h3 class="app-summary-card__title">
       Drugs and alcohol updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -2023,7 +2021,6 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <h3 class="app-summary-card__title">
       Drugs and alcohol updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">

--- a/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
+++ b/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
@@ -618,7 +618,7 @@ exports[`getView Happy path with default query params and data from endpoints 1`
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Drugs and alcohol updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1477,7 +1477,7 @@ exports[`getView Happy path with default query params and no data from endpoints
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Drugs and alcohol updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -2022,7 +2022,7 @@ exports[`getView Happy path with specified query params and data from endpoints 
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Drugs and alcohol updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>

--- a/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
+++ b/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
@@ -459,7 +459,7 @@ exports[`getView Happy path with default query params and data from endpoints 1`
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Education, skills and work updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1384,7 +1384,7 @@ exports[`getView Happy path with default query params and no data from endpoints
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Education, skills and work updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1944,7 +1944,7 @@ exports[`getView Happy path with specified query params and data from endpoints 
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Education, skills and work updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>

--- a/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
+++ b/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
@@ -460,7 +460,6 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <h3 class="app-summary-card__title">
       Education, skills and work updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1385,7 +1384,6 @@ exports[`getView Happy path with default query params and no data from endpoints
     <h3 class="app-summary-card__title">
       Education, skills and work updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1945,7 +1943,6 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <h3 class="app-summary-card__title">
       Education, skills and work updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">

--- a/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
+++ b/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
@@ -455,7 +455,7 @@ exports[`getView Happy path with default query params and data from endpoints 1`
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Finance and ID updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1534,7 +1534,7 @@ exports[`getView Happy path with default query params and no data from endpoints
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Finance and ID updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -2035,7 +2035,7 @@ exports[`getView Happy path with specified query params and data from endpoints 
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Finance and ID updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>

--- a/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
+++ b/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
@@ -456,7 +456,6 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <h3 class="app-summary-card__title">
       Finance and ID updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1535,7 +1534,6 @@ exports[`getView Happy path with default query params and no data from endpoints
     <h3 class="app-summary-card__title">
       Finance and ID updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -2036,7 +2034,6 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <h3 class="app-summary-card__title">
       Finance and ID updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">

--- a/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
+++ b/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
@@ -448,7 +448,6 @@ exports[`getView Happy path with default query params and data from endpoints 1`
     <h3 class="app-summary-card__title">
       Health updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1307,7 +1306,6 @@ exports[`getView Happy path with default query params and no data from endpoints
     <h3 class="app-summary-card__title">
       Health updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">
@@ -1852,7 +1850,6 @@ exports[`getView Happy path with specified query params and data from endpoints 
     <h3 class="app-summary-card__title">
       Health updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">

--- a/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
+++ b/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
@@ -447,7 +447,7 @@ exports[`getView Happy path with default query params and data from endpoints 1`
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Health updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1306,7 +1306,7 @@ exports[`getView Happy path with default query params and no data from endpoints
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Health updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
@@ -1851,7 +1851,7 @@ exports[`getView Happy path with specified query params and data from endpoints 
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       Health updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>

--- a/server/views/partials/supportNeedsSummary.njk
+++ b/server/views/partials/supportNeedsSummary.njk
@@ -4,7 +4,7 @@
        {% if prisonerData.supportNeedsLegacyProfile %}
            <div class="govuk-summary-card__actions">
                <p class="govuk-body-m govuk-!-margin-bottom-0">
-                   New support needs cannot be added for this person.&nbsp;<a class="govuk-link govuk-link--no-visited-state" href="#">Find out why</a>.
+                   New support needs cannot be added for this person.&nbsp;<a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out why</a>.
                </p>
            </div>
        {% else %}

--- a/server/views/partials/supportNeedsUpdates.njk
+++ b/server/views/partials/supportNeedsUpdates.njk
@@ -3,7 +3,6 @@
     <h3 class="app-summary-card__title">
       {{ pathway }} updates
       <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
-      <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>
   <div class="app-summary-card__body govuk-!-padding-top-4">

--- a/server/views/partials/supportNeedsUpdates.njk
+++ b/server/views/partials/supportNeedsUpdates.njk
@@ -2,7 +2,7 @@
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
       {{ pathway }} updates
-      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a href="#">Find out more about this update.</a></span>
+      <span class="govuk-caption-m">Some updates may not be linked to a support need as they were created before support needs were added to PSfR. <a class="govuk-link govuk-link--no-visited-state" href="/service-updates/support-needs">Find out more about this update</a>.</span>
       <!-- TODO - update link to point to service update page. -->
     </h3>
   </header>


### PR DESCRIPTION
When viewing a pathway there are two information links for the support needs updates:

1. On the Support Needs summary card: "New support needs cannot be added for this person. **Find out why.**"
2. On the pathway summary card "Some updates may not be linked to a support need as they were created before support needs were added to PSfR. **Find out more about this update.**"

Both of these links have been updated to point at the **/service-updates/support-needs** page

_(Note: testing note - the first link will only show when viewing a legacy profile)_