### PR TITLE
RSP-1699: Back out validation of searchInput field

### DIFF
--- a/server/routes/assign-case/assignCaseController.test.ts
+++ b/server/routes/assign-case/assignCaseController.test.ts
@@ -279,13 +279,6 @@ describe('getView', () => {
       .expect(400)
       .expect(res => expectSomethingWentWrongPage(res))
   })
-
-  it('Error case - invalid searchInput parameter', async () => {
-    await request(app)
-      .get('/?searchInput=123_456')
-      .expect(400)
-      .expect(res => expectSomethingWentWrongPage(res))
-  })
 })
 
 describe('post', () => {

--- a/server/routes/assign-case/index.ts
+++ b/server/routes/assign-case/index.ts
@@ -20,7 +20,6 @@ export default (router: Router, services: Services) => {
       query('workerId').isEmpty().optional(), // all workers
     ]),
     oneOf([query('currentPage').isInt({ min: 0 }).optional(), query('currentPage').isEmpty().optional()]),
-    oneOf([query('searchInput').isAlphanumeric().optional(), query('searchInput').isEmpty().optional()]),
     [asyncWrapper(assignCase.getView)],
   )
   router.post('/assign-a-case', [asyncWrapper(assignCase.assignCases)])

--- a/server/routes/staffDashboard/index.ts
+++ b/server/routes/staffDashboard/index.ts
@@ -18,8 +18,6 @@ export default (router: Router, services: Services) => {
       query('lastReportCompleted').isIn(['BCST2', 'RESETTLEMENT_PLAN', '', 'NONE']).optional(),
     ],
     oneOf([query('assessmentRequired').isBoolean().optional(), query('assessmentRequired').isEmpty().optional()]),
-    // Requires searchInput to be alphanumeric. NOMIS doesn't support accented characters, so we don't need to allow for them here.
-    oneOf([query('searchInput').isAlphanumeric().optional(), query('searchInput').isEmpty().optional()]),
     [staffDashboardController.getView],
   )
 }

--- a/server/routes/staffDashboard/staffDashboardController.test.ts
+++ b/server/routes/staffDashboard/staffDashboardController.test.ts
@@ -505,11 +505,4 @@ describe('getView', () => {
       .expect(400)
       .expect(res => expectSomethingWentWrongPage(res))
   })
-
-  it('Error case - invalid searchInput parameter', async () => {
-    await request(app)
-      .get('/?searchInput=john%^')
-      .expect(400)
-      .expect(res => expectSomethingWentWrongPage(res))
-  })
 })


### PR DESCRIPTION
Remove validation of the searchInput field on the prisoner overview and assign-a-case pages.  This will be revised and re-added at a later date.