### PR TITLE
[RSP-2040] Improve error handling for support needs journey.

### DIFF
--- a/server/routes/support-needs/supportNeedsController.ts
+++ b/server/routes/support-needs/supportNeedsController.ts
@@ -16,6 +16,7 @@ import { updateSupportNeedsWithRequestBody } from '../../utils/updateSupportNeed
 import SupportNeedForm from './supportNeedsForm'
 import { CustomValidationError } from '../../@types/express'
 import { CUSTOM_OTHER_PREFIX, SUPPORT_NEED_OPTION_PREFIX } from './supportNeedsContants'
+import { handleSupportNeedsNotFoundRedirect } from '../../utils/supportNeedsErrorHandler'
 
 export default class SupportNeedsController {
   constructor(
@@ -113,7 +114,7 @@ export default class SupportNeedsController {
         errors,
       })
     } catch (err) {
-      next(err)
+      handleSupportNeedsNotFoundRedirect(err, req, res, next)
     }
   }
 
@@ -153,7 +154,7 @@ export default class SupportNeedsController {
 
       return res.redirect(`/support-needs/${pathway}/status/${firstUpdatablePageId}/?prisonerNumber=${prisonerNumber}`)
     } catch (err) {
-      return next(err)
+      return handleSupportNeedsNotFoundRedirect(err, req, res, next)
     }
   }
 
@@ -210,7 +211,7 @@ export default class SupportNeedsController {
         ...form.renderArgs,
       })
     } catch (err) {
-      return next(err)
+      return handleSupportNeedsNotFoundRedirect(err, req, res, next)
     }
   }
 
@@ -275,7 +276,7 @@ export default class SupportNeedsController {
         `/support-needs/${pathway}/status/${nextUpdatableSupportNeedPageId}/?prisonerNumber=${prisonerNumber}`,
       )
     } catch (err) {
-      return next(err)
+      return handleSupportNeedsNotFoundRedirect(err, req, res, next)
     }
   }
 
@@ -326,7 +327,7 @@ export default class SupportNeedsController {
         backLink,
       })
     } catch (err) {
-      return next(err)
+      return handleSupportNeedsNotFoundRedirect(err, req, res, next)
     }
   }
 
@@ -374,7 +375,7 @@ export default class SupportNeedsController {
 
       res.redirect(`/${pathway}/?prisonerNumber=${prisonerNumber}#support-needs`)
     } catch (err) {
-      next(err)
+      handleSupportNeedsNotFoundRedirect(err, req, res, next)
     }
   }
 
@@ -434,7 +435,7 @@ export default class SupportNeedsController {
       }
       return res.redirect(`/support-needs/${pathway}/check-answers?prisonerNumber=${prisonerNumber}`)
     } catch (err) {
-      return next(err)
+      return handleSupportNeedsNotFoundRedirect(err, req, res, next)
     }
   }
 
@@ -553,7 +554,7 @@ export default class SupportNeedsController {
       req.validationErrors = validationErrors
       return next()
     } catch (err) {
-      return next(err)
+      return handleSupportNeedsNotFoundRedirect(err, req, _res, next)
     }
   }
 }

--- a/server/utils/supportNeedsErrorHandler.test.ts
+++ b/server/utils/supportNeedsErrorHandler.test.ts
@@ -1,0 +1,46 @@
+import { Request, Response, NextFunction } from 'express'
+import { handleSupportNeedsNotFoundRedirect } from './supportNeedsErrorHandler' // adjust path
+import { SupportNeedsNotFoundInCacheError } from '../data/supportNeedStateService'
+import { PersonalDetails, PrisonerData } from '../@types/express' // adjust path
+
+describe('handleSupportNeedsNotFoundRedirect', () => {
+  const prisonerNumber = 'A1234BC'
+  const pathway = 'accommodation'
+  const personalDetails = { firstName: 'fred', lastName: 'FlintstOne', prisonerNumber } as PersonalDetails
+  const prisonerData = { personalDetails } as PrisonerData
+
+  let req: Partial<Request>
+  let res: Partial<Response>
+  let next: jest.Mock
+
+  beforeEach(() => {
+    req = {
+      params: { pathway },
+      prisonerData,
+    }
+
+    res = {
+      redirect: jest.fn(),
+    }
+
+    next = jest.fn()
+  })
+
+  it('should redirect if error is SupportNeedsNotFoundInCacheError', () => {
+    const err = new SupportNeedsNotFoundInCacheError('Not found in cache')
+
+    handleSupportNeedsNotFoundRedirect(err, req as Request, res as Response, next as NextFunction)
+
+    expect(res.redirect).toHaveBeenCalledWith(`/${pathway}?prisonerNumber=${prisonerNumber}`)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('should call next(err) if error is not SupportNeedsNotFoundInCacheError', () => {
+    const err = new Error('Some other error')
+
+    handleSupportNeedsNotFoundRedirect(err, req as Request, res as Response, next as NextFunction)
+
+    expect(next).toHaveBeenCalledWith(err)
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+})

--- a/server/utils/supportNeedsErrorHandler.ts
+++ b/server/utils/supportNeedsErrorHandler.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express'
+import { SupportNeedsNotFoundInCacheError } from '../data/supportNeedStateService'
+
+export function handleSupportNeedsNotFoundRedirect(
+  err: unknown,
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (err instanceof SupportNeedsNotFoundInCacheError) {
+    const { pathway } = req.params
+    const { prisonerNumber } = req.prisonerData.personalDetails
+    res.redirect(`/${pathway}?prisonerNumber=${prisonerNumber}`)
+  } else {
+    next(err)
+  }
+}


### PR DESCRIPTION
- Redirects to pathway landing page if pathway data not found in cache due to:
  - User pressing browser back
  - Directly navigating to an intermediate (bookmarked/copied) URL from a pathway journey.