### PR TITLE
RSP-2044: Update govuk-frontend version to fix security pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "express-session": "^1.18.1",
         "express-validator": "^7.2.1",
         "formidable": "^3.5.4",
-        "govuk-frontend": "^5.9.0",
+        "govuk-frontend": "^5.10.0",
         "helmet": "^8.1.0",
         "http-errors": "^2.0.0",
         "jquery": "^3.7.1",
@@ -9162,9 +9162,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
-      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.0.tgz",
+      "integrity": "sha512-9tjpB8PDwsDqutkQPJXfDalLvNOeKxzFhV7me21s/oyn7HcTg/ei/GC3Y4JvNsXauzjOkxv4eeCHntKeySkdMg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "express-session": "^1.18.1",
     "express-validator": "^7.2.1",
     "formidable": "^3.5.4",
-    "govuk-frontend": "^5.9.0",
+    "govuk-frontend": "^5.10.0",
     "helmet": "^8.1.0",
     "http-errors": "^2.0.0",
     "jquery": "^3.7.1",

--- a/server/__snapshots__/errorHandler.test.ts.snap
+++ b/server/__snapshots__/errorHandler.test.ts.snap
@@ -498,6 +498,7 @@ exports[`GET 404 should render something went wrong page 1`] = `
     <footer class="govuk-footer govuk-!-display-none-print">
   <div class="govuk-width-container">
     
+    
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         


### PR DESCRIPTION
Update govuk-frontend to version 5.10.0 (latest version). 