### PR TITLE
RSP-2008: Refactor validation of pathway params

### DIFF
--- a/server/routes/accommodation/accommodationController.ts
+++ b/server/routes/accommodation/accommodationController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express'
-import { query, validationResult } from 'express-validator'
+import { validationResult } from 'express-validator'
 import AccommodationView from './accommodationView'
 import RpService from '../../services/rpService'
 import { handleWhatsNewBanner } from '../whatsNewBanner'

--- a/server/routes/accommodation/accommodationController.ts
+++ b/server/routes/accommodation/accommodationController.ts
@@ -13,19 +13,6 @@ export default class AccommodationController {
     // no op
   }
 
-  // Validation for query parameters
-  validateQuery = [
-    query('supportNeedUpdateFilter')
-      .optional()
-      .custom(value => value === '' || /^[0-9]+$/.test(value)) // Check if it's either an empty string or a string with a number
-      .withMessage('supportNeedUpdateFilter must be a number or empty'),
-
-    query('supportNeedUpdateSort')
-      .optional()
-      .isIn(['createdDate,DESC', 'createdDate,ASC'])
-      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
-  ]
-
   getView: RequestHandler = async (req, res, next): Promise<void> => {
     try {
       // Load prisoner data

--- a/server/routes/accommodation/index.ts
+++ b/server/routes/accommodation/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import AccommodationController from './accommodationController'
-import { getValidationForPathwayQuery } from '../../utils/utils'
+import { getValidationForPathwayQuery } from '../validation'
 
 export default (router: Router, services: Services) => {
   const accommodationController = new AccommodationController(services.rpService, services.prisonerDetailsService)

--- a/server/routes/accommodation/index.ts
+++ b/server/routes/accommodation/index.ts
@@ -5,7 +5,5 @@ import { getValidationForPathwayQuery } from '../../utils/utils'
 
 export default (router: Router, services: Services) => {
   const accommodationController = new AccommodationController(services.rpService, services.prisonerDetailsService)
-  router.get('/accommodation', accommodationController.validateQuery.concat(getValidationForPathwayQuery()), [
-    accommodationController.getView,
-  ])
+  router.get('/accommodation', getValidationForPathwayQuery(), [accommodationController.getView])
 }

--- a/server/routes/attitudes-thinking-behaviour/attitudesThinkingBehaviourController.ts
+++ b/server/routes/attitudes-thinking-behaviour/attitudesThinkingBehaviourController.ts
@@ -13,14 +13,6 @@ export default class AttitudesThinkingBehaviourController {
     // no op
   }
 
-  // Validation for query parameters
-  validateQuery = [
-    query('supportNeedUpdateSort')
-      .optional()
-      .isIn(['createdDate,DESC', 'createdDate,ASC'])
-      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
-  ]
-
   getView: RequestHandler = async (req, res, next): Promise<void> => {
     try {
       const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, true)

--- a/server/routes/attitudes-thinking-behaviour/attitudesThinkingBehaviourController.ts
+++ b/server/routes/attitudes-thinking-behaviour/attitudesThinkingBehaviourController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express'
-import { query, validationResult } from 'express-validator'
+import { validationResult } from 'express-validator'
 import RpService from '../../services/rpService'
 import AttitudesThinkingBehaviour from './attitudesThinkingBehaviourView'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'

--- a/server/routes/attitudes-thinking-behaviour/index.ts
+++ b/server/routes/attitudes-thinking-behaviour/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import AttitudesThinkingBehaviourController from './attitudesThinkingBehaviourController'
-import { getValidationForPathwayQuery } from '../../utils/utils'
+import { getValidationForPathwayQuery } from '../validation'
 
 export default (router: Router, services: Services) => {
   const attitudesThinkingBehaviourController = new AttitudesThinkingBehaviourController(

--- a/server/routes/attitudes-thinking-behaviour/index.ts
+++ b/server/routes/attitudes-thinking-behaviour/index.ts
@@ -9,9 +9,7 @@ export default (router: Router, services: Services) => {
     services.prisonerDetailsService,
   )
 
-  router.get(
-    '/attitudes-thinking-and-behaviour',
-    attitudesThinkingBehaviourController.validateQuery.concat(getValidationForPathwayQuery()),
-    [attitudesThinkingBehaviourController.getView],
-  )
+  router.get('/attitudes-thinking-and-behaviour', getValidationForPathwayQuery(), [
+    attitudesThinkingBehaviourController.getView,
+  ])
 }

--- a/server/routes/children-families-and-communities/childrenFamiliesCommunitiesController.ts
+++ b/server/routes/children-families-and-communities/childrenFamiliesCommunitiesController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express'
-import { query, validationResult } from 'express-validator'
+import { validationResult } from 'express-validator'
 import RpService from '../../services/rpService'
 import ChildrenFamiliesCommunitiesView from './childrenFamiliesCommunitiesView'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'

--- a/server/routes/children-families-and-communities/childrenFamiliesCommunitiesController.ts
+++ b/server/routes/children-families-and-communities/childrenFamiliesCommunitiesController.ts
@@ -13,14 +13,6 @@ export default class ChildrenFamiliesCommunitiesController {
     // no op
   }
 
-  // Validation for query parameters
-  validateQuery = [
-    query('supportNeedUpdateSort')
-      .optional()
-      .isIn(['createdDate,DESC', 'createdDate,ASC'])
-      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
-  ]
-
   getView: RequestHandler = async (req, res, next): Promise<void> => {
     try {
       const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, true)

--- a/server/routes/children-families-and-communities/index.ts
+++ b/server/routes/children-families-and-communities/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import ChildrenFamiliesCommunitiesController from './childrenFamiliesCommunitiesController'
-import { getValidationForPathwayQuery } from '../../utils/utils'
+import { getValidationForPathwayQuery } from '../validation'
 
 export default (router: Router, services: Services) => {
   const childrenFamiliesCommunitiesController = new ChildrenFamiliesCommunitiesController(

--- a/server/routes/children-families-and-communities/index.ts
+++ b/server/routes/children-families-and-communities/index.ts
@@ -9,9 +9,7 @@ export default (router: Router, services: Services) => {
     services.prisonerDetailsService,
   )
 
-  router.get(
-    '/children-families-and-communities',
-    childrenFamiliesCommunitiesController.validateQuery.concat(getValidationForPathwayQuery()),
-    [childrenFamiliesCommunitiesController.getView],
-  )
+  router.get('/children-families-and-communities', getValidationForPathwayQuery(), [
+    childrenFamiliesCommunitiesController.getView,
+  ])
 }

--- a/server/routes/drugs-alcohol/drugsAlcoholController.ts
+++ b/server/routes/drugs-alcohol/drugsAlcoholController.ts
@@ -13,14 +13,6 @@ export default class DrugsAlcoholController {
     // no op
   }
 
-  // Validation for query parameters
-  validateQuery = [
-    query('supportNeedUpdateSort')
-      .optional()
-      .isIn(['createdDate,DESC', 'createdDate,ASC'])
-      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
-  ]
-
   getView: RequestHandler = async (req, res, next): Promise<void> => {
     try {
       const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, true)

--- a/server/routes/drugs-alcohol/drugsAlcoholController.ts
+++ b/server/routes/drugs-alcohol/drugsAlcoholController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express'
-import { query, validationResult } from 'express-validator'
+import { validationResult } from 'express-validator'
 import RpService from '../../services/rpService'
 import DrugsAlcoholView from './drugsAlcoholView'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'

--- a/server/routes/drugs-alcohol/index.ts
+++ b/server/routes/drugs-alcohol/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import DrugsAlcoholController from './drugsAlcoholController'
-import { getValidationForPathwayQuery } from '../../utils/utils'
+import { getValidationForPathwayQuery } from '../validation'
 
 export default (router: Router, services: Services) => {
   const drugsAlcoholController = new DrugsAlcoholController(services.rpService, services.prisonerDetailsService)

--- a/server/routes/drugs-alcohol/index.ts
+++ b/server/routes/drugs-alcohol/index.ts
@@ -6,7 +6,5 @@ import { getValidationForPathwayQuery } from '../../utils/utils'
 export default (router: Router, services: Services) => {
   const drugsAlcoholController = new DrugsAlcoholController(services.rpService, services.prisonerDetailsService)
 
-  router.get('/drugs-and-alcohol', drugsAlcoholController.validateQuery.concat(getValidationForPathwayQuery()), [
-    drugsAlcoholController.getView,
-  ])
+  router.get('/drugs-and-alcohol', getValidationForPathwayQuery(), [drugsAlcoholController.getView])
 }

--- a/server/routes/education-skills-work/educationSkillsWorkController.ts
+++ b/server/routes/education-skills-work/educationSkillsWorkController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express'
-import { query, validationResult } from 'express-validator'
+import { validationResult } from 'express-validator'
 import RpService from '../../services/rpService'
 import EducationSkillsWorkView from './educationSkillsWorkView'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'

--- a/server/routes/education-skills-work/educationSkillsWorkController.ts
+++ b/server/routes/education-skills-work/educationSkillsWorkController.ts
@@ -13,14 +13,6 @@ export default class EducationSkillsWorkController {
     // no op
   }
 
-  // Validation for query parameters
-  validateQuery = [
-    query('supportNeedUpdateSort')
-      .optional()
-      .isIn(['createdDate,DESC', 'createdDate,ASC'])
-      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
-  ]
-
   getView: RequestHandler = async (req, res, next): Promise<void> => {
     try {
       const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, true)

--- a/server/routes/education-skills-work/index.ts
+++ b/server/routes/education-skills-work/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import EducationSkillsWorkController from './educationSkillsWorkController'
-import { getValidationForPathwayQuery } from '../../utils/utils'
+import { getValidationForPathwayQuery } from '../validation'
 
 export default (router: Router, services: Services) => {
   const educationSkillsWorkController = new EducationSkillsWorkController(

--- a/server/routes/education-skills-work/index.ts
+++ b/server/routes/education-skills-work/index.ts
@@ -8,9 +8,5 @@ export default (router: Router, services: Services) => {
     services.rpService,
     services.prisonerDetailsService,
   )
-  router.get(
-    '/education-skills-and-work',
-    educationSkillsWorkController.validateQuery.concat(getValidationForPathwayQuery()),
-    [educationSkillsWorkController.getView],
-  )
+  router.get('/education-skills-and-work', getValidationForPathwayQuery(), [educationSkillsWorkController.getView])
 }

--- a/server/routes/finance-id/financeIdController.ts
+++ b/server/routes/finance-id/financeIdController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express'
-import { query, validationResult } from 'express-validator'
+import { validationResult } from 'express-validator'
 import { isAlphanumeric, isNumeric } from 'validator'
 import RpService from '../../services/rpService'
 import logger from '../../../logger'

--- a/server/routes/finance-id/financeIdController.ts
+++ b/server/routes/finance-id/financeIdController.ts
@@ -16,14 +16,6 @@ export default class FinanceIdController {
     // no op
   }
 
-  // Validation for query parameters
-  validateQuery = [
-    query('supportNeedUpdateSort')
-      .optional()
-      .isIn(['createdDate,DESC', 'createdDate,ASC'])
-      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
-  ]
-
   getView: RequestHandler = async (req, res, next): Promise<void> => {
     try {
       const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res)

--- a/server/routes/finance-id/index.ts
+++ b/server/routes/finance-id/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import FinanceIdController from './financeIdController'
-import { getValidationForPathwayQuery } from '../../utils/utils'
+import { getValidationForPathwayQuery } from '../validation'
 
 export default (router: Router, services: Services) => {
   const financeIdController = new FinanceIdController(services.rpService, services.prisonerDetailsService)

--- a/server/routes/finance-id/index.ts
+++ b/server/routes/finance-id/index.ts
@@ -6,9 +6,7 @@ import { getValidationForPathwayQuery } from '../../utils/utils'
 export default (router: Router, services: Services) => {
   const financeIdController = new FinanceIdController(services.rpService, services.prisonerDetailsService)
 
-  router.get('/finance-and-id', financeIdController.validateQuery.concat(getValidationForPathwayQuery()), [
-    financeIdController.getView,
-  ])
+  router.get('/finance-and-id', getValidationForPathwayQuery(), [financeIdController.getView])
   router.post('/finance-and-id/bank-account-delete', [financeIdController.postBankAccountDelete])
   router.post('/finance-and-id/id-delete', [financeIdController.postIdDelete])
 }

--- a/server/routes/health-status/healthStatusController.ts
+++ b/server/routes/health-status/healthStatusController.ts
@@ -13,14 +13,6 @@ export default class HealthStatusController {
     // no op
   }
 
-  // Validation for query parameters
-  validateQuery = [
-    query('supportNeedUpdateSort')
-      .optional()
-      .isIn(['createdDate,DESC', 'createdDate,ASC'])
-      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
-  ]
-
   getView: RequestHandler = async (req, res, next): Promise<void> => {
     try {
       const prisonerData = await this.prisonerDetailsService.loadPrisonerDetailsFromParam(req, res, true)

--- a/server/routes/health-status/healthStatusController.ts
+++ b/server/routes/health-status/healthStatusController.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express'
-import { query, validationResult } from 'express-validator'
+import { validationResult } from 'express-validator'
 import RpService from '../../services/rpService'
 import HealthStatusView from './healthStatusView'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'

--- a/server/routes/health-status/index.ts
+++ b/server/routes/health-status/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import HealthStatusController from './healthStatusController'
-import { getValidationForPathwayQuery } from '../../utils/utils'
+import { getValidationForPathwayQuery } from '../validation'
 
 export default (router: Router, services: Services) => {
   const healthController = new HealthStatusController(services.rpService, services.prisonerDetailsService)

--- a/server/routes/health-status/index.ts
+++ b/server/routes/health-status/index.ts
@@ -6,7 +6,5 @@ import { getValidationForPathwayQuery } from '../../utils/utils'
 export default (router: Router, services: Services) => {
   const healthController = new HealthStatusController(services.rpService, services.prisonerDetailsService)
 
-  router.get('/health-status', healthController.validateQuery.concat(getValidationForPathwayQuery()), [
-    healthController.getView,
-  ])
+  router.get('/health-status', getValidationForPathwayQuery(), [healthController.getView])
 }

--- a/server/routes/validation.ts
+++ b/server/routes/validation.ts
@@ -1,0 +1,16 @@
+import { FieldValidationError, query, ValidationChain } from 'express-validator'
+
+export function getValidationForPathwayQuery(): ValidationChain[] {
+  return [
+    query('page').isInt({ min: 0 }).optional().withMessage('page must be a positive integer'),
+    query('createdByUserId').isInt({ min: 0 }).optional().withMessage('createdByUserId must be a positive integer'),
+    query('supportNeedsUpdatesPage')
+      .isInt({ min: 0 })
+      .optional()
+      .withMessage('supportNeedsUpdatesPage must be a positive integer'),
+    query('supportNeedUpdateSort')
+      .isIn(['createdDate,DESC', 'createdDate,ASC'])
+      .optional()
+      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
+  ]
+}

--- a/server/routes/validation.ts
+++ b/server/routes/validation.ts
@@ -1,4 +1,4 @@
-import { FieldValidationError, query, ValidationChain } from 'express-validator'
+import { query, ValidationChain } from 'express-validator'
 
 export function getValidationForPathwayQuery(): ValidationChain[] {
   return [

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,6 +1,6 @@
 import { Callback } from 'nunjucks'
 import { addMinutes, format } from 'date-fns'
-import { FieldValidationError, query, ValidationChain } from 'express-validator'
+import { FieldValidationError } from 'express-validator'
 import { PathwayStatus, PrisonerData } from '../@types/express'
 import {
   ASSESSMENT_ENUMS_DICTIONARY,
@@ -622,21 +622,6 @@ export function validateStringIsAnInteger(input: string) {
   if (!/^[1-9](\d+)?$/.test(input)) {
     throw new Error(`Input ${input} is not a valid integer`)
   }
-}
-
-export function getValidationForPathwayQuery(): ValidationChain[] {
-  return [
-    query('page').isInt({ min: 0 }).optional().withMessage('page must be a positive integer'),
-    query('createdByUserId').isInt({ min: 0 }).optional().withMessage('createdByUserId must be a positive integer'),
-    query('supportNeedsUpdatesPage')
-      .isInt({ min: 0 })
-      .optional()
-      .withMessage('supportNeedsUpdatesPage must be a positive integer'),
-    query('supportNeedUpdateSort')
-      .isIn(['createdDate,DESC', 'createdDate,ASC'])
-      .optional()
-      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
-  ]
 }
 
 export function processSupportNeedsRequestBody(input: Record<string, string | string[]>): PrisonerSupportNeedsPatch {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -626,9 +626,16 @@ export function validateStringIsAnInteger(input: string) {
 
 export function getValidationForPathwayQuery(): ValidationChain[] {
   return [
-    query('page').isInt({ min: 0 }).optional(),
-    query('createdByUserId').isInt({ min: 0 }).optional(),
-    query('supportNeedsUpdatesPage').isInt({ min: 0 }).optional(),
+    query('page').isInt({ min: 0 }).optional().withMessage('page must be a positive integer'),
+    query('createdByUserId').isInt({ min: 0 }).optional().withMessage('createdByUserId must be a positive integer'),
+    query('supportNeedsUpdatesPage')
+      .isInt({ min: 0 })
+      .optional()
+      .withMessage('supportNeedsUpdatesPage must be a positive integer'),
+    query('supportNeedUpdateSort')
+      .isIn(['createdDate,DESC', 'createdDate,ASC'])
+      .optional()
+      .withMessage('supportNeedUpdateSort must be createdDate,DESC or createdDate,ASC'),
   ]
 }
 


### PR DESCRIPTION
- Move validation of `supportNeedUpdateSort` field out of individual pathway pages and into common utility function. 
- Remove validation of non-existent `supportNeedUpdateFilter` field from accommodation page