### PR TITLE
RSP-2050 Remove 'reset profile' button and routes when read-only

### DIFF
--- a/server/routes/prisoner-overview/__snapshots__/prisonerOverviewController.test.ts.snap
+++ b/server/routes/prisoner-overview/__snapshots__/prisonerOverviewController.test.ts.snap
@@ -294,6 +294,7 @@ exports[`prisonerOverview happy path with default query parameters 1`] = `
   
   
   
+    
   <div class="govuk-grid-column-one-third">
     <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
       <header class="app-summary-card__header">
@@ -323,6 +324,7 @@ exports[`prisonerOverview happy path with default query parameters 1`] = `
     </section>
   </div>
 
+  
 </div>
 
   <div class="govuk-grid-row govuk-!-padding-top-4">
@@ -1381,6 +1383,7 @@ exports[`prisonerOverview should display error when supportNeeds is enabled and 
   
   
   
+    
   <div class="govuk-grid-column-one-third">
     <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
       <header class="app-summary-card__header">
@@ -1393,6 +1396,7 @@ exports[`prisonerOverview should display error when supportNeeds is enabled and 
     </section>
   </div>
 
+  
 </div>
 
   <div class="govuk-grid-row govuk-!-padding-top-4">
@@ -2405,6 +2409,7 @@ exports[`prisonerOverview should display responsible staff data when supportNeed
   
   
   
+    
   <div class="govuk-grid-column-one-third">
     <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
       <header class="app-summary-card__header">
@@ -2417,6 +2422,7 @@ exports[`prisonerOverview should display responsible staff data when supportNeed
     </section>
   </div>
 
+  
 </div>
 
   <div class="govuk-grid-row govuk-!-padding-top-4">
@@ -3583,6 +3589,7 @@ exports[`prisonerOverview should render the prisoner overview page with correct 
   
   
   
+    
   <div class="govuk-grid-column-one-third">
     <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
       <header class="app-summary-card__header">
@@ -3612,6 +3619,7 @@ exports[`prisonerOverview should render the prisoner overview page with correct 
     </section>
   </div>
 
+  
 </div>
 
   <div class="govuk-grid-row govuk-!-padding-top-4">
@@ -4657,6 +4665,7 @@ exports[`prisonerOverview should render the prisoner overview page with correct 
   
   
   
+    
   <div class="govuk-grid-column-one-third">
     <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
       <header class="app-summary-card__header">
@@ -4686,6 +4695,7 @@ exports[`prisonerOverview should render the prisoner overview page with correct 
     </section>
   </div>
 
+  
 </div>
 
   <div class="govuk-grid-row govuk-!-padding-top-4">
@@ -5731,6 +5741,7 @@ exports[`prisonerOverview should render the prisoner overview page without retri
   
   
   
+    
   <div class="govuk-grid-column-one-third">
     <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
       <header class="app-summary-card__header">
@@ -5760,6 +5771,7 @@ exports[`prisonerOverview should render the prisoner overview page without retri
     </section>
   </div>
 
+  
 </div>
 
   <div class="govuk-grid-row govuk-!-padding-top-4">

--- a/server/routes/prisoner-overview/__snapshots__/prisonerOverviewController.test.ts.snap
+++ b/server/routes/prisoner-overview/__snapshots__/prisonerOverviewController.test.ts.snap
@@ -1091,6 +1091,3091 @@ S1 2NP</td>
 "
 `;
 
+exports[`prisonerOverview should display "reset profile" button and NO other tasks when readOnlyMode is false and tasksView is false 1`] = `
+"<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8">
+    <title>Prepare someone for release - Resettlement overview
+</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+
+    
+      <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
+      <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/assets/manifest.json">
+    
+
+    
+  <link href="/assets/stylesheets/application.css?" rel="stylesheet" />
+  <script src="/assets/js/jquery.min.js"></script>
+  
+  <!--<![endif]-->
+  
+  
+  <script src="/assets/analytics.js" nonce=""></script>
+  <meta name="csrf-token" content="">
+
+    
+  </head>
+  <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    
+
+    
+      <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+    
+
+    
+  
+    
+    
+<header class="fallback-dps-header" role="banner">
+  <div class="fallback-dps-header__container">
+    <div class="fallback-dps-header__title">
+      <a class="fallback-dps-header__link fallback-dps-header__link--no-underline fallback-dps-header__title__service-name" href="#">
+        <svg role="presentation" focusable="false" class="fallback-dps-header__logo" xmlns="http://www.w3.org/2000/svg" width="41" height="30" viewBox="0 0 41 30">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M7.54677 9.20065C8.64351 9.65301 9.88802 9.13584 10.3347 8.05183C10.7839 6.97073 10.27 5.71374 9.17342 5.26352C8.09836 4.82212 6.84843 5.34938 6.40124 6.4349C5.95404 7.515 6.47121 8.76014 7.54677 9.20065Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M2.71865 12.0298C3.81564 12.4821 5.0599 11.965 5.50659 10.881C5.9558 9.79984 5.44191 8.54286 4.34529 8.09264C3.27023 7.65124 2.02031 8.17837 1.57311 9.26402C1.12592 10.3441 1.64308 11.5891 2.71865 12.0298Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M1.3065 17.397C2.4035 17.8494 3.648 17.3322 4.09469 16.2481C4.54391 15.1669 4.02977 13.91 2.9334 13.4599C1.85834 13.0183 0.608415 13.5457 0.160968 14.6311C-0.286227 15.7112 0.231192 16.9565 1.3065 17.397Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M12.9335 10.9018C14.0302 11.3542 15.2747 10.837 15.7214 9.75301C16.1706 8.6719 15.6568 7.41491 14.5601 6.96469C13.4851 6.52329 12.2351 7.05055 11.788 8.13607C11.3408 9.21617 11.8579 10.4613 12.9335 10.9018Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M32.4543 9.20065C31.3573 9.65301 30.1131 9.13584 29.6661 8.05183C29.2172 6.97073 29.7308 5.71374 30.8274 5.26352C31.9027 4.82212 33.1527 5.34938 33.5999 6.4349C34.0471 7.515 33.5299 8.76014 32.4543 9.20065Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M37.2805 12.0298C36.1833 12.4821 34.939 11.965 34.4923 10.881C34.0433 9.79984 34.557 8.54286 35.6536 8.09264C36.7289 7.65124 37.9788 8.17837 38.426 9.26402C38.8732 10.3441 38.3558 11.5891 37.2805 12.0298Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M38.6944 17.397C37.5977 17.8494 36.3532 17.3322 35.9065 16.2481C35.4573 15.1669 35.9712 13.91 37.0678 13.4599C38.1428 13.0183 39.3928 13.5457 39.84 14.6311C40.2874 15.7112 39.77 16.9565 38.6944 17.397Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M27.0657 10.9018C25.9687 11.3542 24.7244 10.837 24.2775 9.75301C23.8285 8.6719 24.3421 7.41491 25.4388 6.96469C26.5141 6.52329 27.764 7.05055 28.2112 8.13607C28.6584 9.21617 28.1412 10.4613 27.0657 10.9018Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M21.1246 5.39912L21.1311 5.39294L23.8259 6.80828V2.83635L21.1342 3.68851L21.1266 3.68044C21.0512 3.58147 20.9639 3.49284 20.8653 3.41656L20.858 3.40899L21.9407 0L19.9961 0.000252154L18.0507 0L19.1337 3.40899L19.1263 3.41656C19.0281 3.49284 18.9402 3.58147 18.8653 3.68044L18.8573 3.68851L16.166 2.83635V6.80828L18.8609 5.39294L18.8673 5.39912C18.9471 5.50351 19.0407 5.5963 19.1458 5.67498L17.5981 10.344C17.5962 10.3498 17.5942 10.3556 17.5925 10.3611L17.5908 10.366L17.5913 10.3666C17.5193 10.5997 17.4807 10.847 17.4807 11.1036C17.4807 12.3669 18.4127 13.4095 19.6264 13.5887C19.6445 13.5915 19.6621 13.5946 19.6804 13.5968C19.7838 13.61 19.8884 13.6188 19.9956 13.6188H19.9961H19.9964C20.1031 13.6188 20.2079 13.61 20.3116 13.5968C20.3295 13.5946 20.3472 13.5915 20.3655 13.5887C21.5788 13.4095 22.5112 12.3669 22.5112 11.1036C22.5112 10.847 22.4721 10.5997 22.4006 10.3666L22.4009 10.366L22.3994 10.3611C22.3975 10.3556 22.3955 10.3498 22.3935 10.344L20.8461 5.67498C20.951 5.5963 21.0448 5.50351 21.1246 5.39912Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M19.9961 28.2469C25.1126 28.2469 29.9557 28.5936 34.2707 29.2111C35.4958 24.0612 36.9865 21.1103 38.5258 19.0092L35.6272 17.978C35.9156 19.4496 35.9616 20.1346 35.6388 21.0806C35.1608 20.6133 34.7078 19.7539 34.3542 18.4405L32.95 23.1175C33.8045 22.529 34.4635 22.1489 35.2174 22.1306C33.8799 25.0107 32.2103 25.7519 31.1284 25.552C29.8069 25.3094 29.1998 24.1313 29.4046 23.1324C29.7085 21.7159 31.1616 21.3468 31.8404 22.994C33.1384 20.3461 30.9362 19.5212 29.5189 20.3045C31.6957 18.1333 31.9448 16.2036 30.1877 13.8682C27.7395 15.7394 27.7109 17.5926 28.8127 20.1999C27.383 18.5638 25.1586 19.4422 25.9621 22.0859C26.9932 20.4897 28.3578 21.4937 28.1436 23.0095C27.9627 24.3308 26.2183 25.3978 24.0464 25.2087C20.9338 24.9265 20.7484 22.7785 20.6709 21.0011C21.4362 20.8593 22.814 21.5684 23.9887 23.2183L24.4217 18.2575C23.1434 19.5894 21.9821 19.8421 20.6921 19.8829C21.1215 18.5433 23.0951 16.3481 23.0951 16.3481L20.2276 16.3478H20.2261H20.2248L16.9033 16.3481C16.9033 16.3481 18.877 18.5433 19.3061 19.8829C18.0163 19.8421 16.8551 19.5894 15.5765 18.2575L16.0097 23.2183C17.1847 21.5684 18.5623 20.8593 19.3276 21.0011C19.2503 22.7785 19.0648 24.9265 15.9521 25.2087C13.7802 25.3978 12.036 24.3308 11.8548 23.0095C11.6406 21.4937 13.0053 20.4897 14.0365 22.0859C14.8401 19.4422 12.6152 18.5638 11.186 20.1999C12.2877 17.5926 12.2587 15.7394 9.81076 13.8682C8.0535 16.2036 8.3025 18.1333 10.4793 20.3045C9.06211 19.5212 6.86005 20.3461 8.15814 22.994C8.83681 21.3468 10.2902 21.7159 10.5941 23.1324C10.7989 24.1313 10.1911 25.3094 8.87035 25.552C7.78836 25.7519 6.11859 25.0107 4.78117 22.1306C5.53523 22.1489 6.19361 22.529 7.04866 23.1175L5.64454 18.4405C5.29039 19.7539 4.8379 20.6133 4.35969 21.0806C4.03656 20.1346 4.08283 19.4496 4.37091 17.978L1.47266 19.0092C3.01218 21.11 4.50241 24.0607 5.72725 29.21C10.041 28.5931 14.8817 28.2469 19.9961 28.2469Z"/>
+        </svg>
+        Digital Prison Services
+      </a>
+
+      
+    </div>
+
+    <nav aria-label="Account navigation">
+      <ul class="fallback-dps-header__navigation">
+        
+          <li class="fallback-dps-header__navigation__item">
+            <span data-qa=header-user-name>F. Last</span>
+          </li>
+        
+
+        <li class="fallback-dps-header__navigation__item">
+          <a data-qa="signOut" class="fallback-dps-header__link fallback-dps-header__link--no-underline fallback-dps-header__sign-out" href="/sign-out">Sign out</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+  
+
+  <div class="govuk-width-container">
+    
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      BETA
+    </strong>
+    <span class="govuk-phase-banner__text">
+      This is a new service – your <a class="govuk-link" target="_blank" rel="noopener noreferrer"
+                                                            href="https://www.smartsurvey.co.uk/s/QQV2UP">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>
+
+    
+      
+    
+    
+      
+      
+    
+
+    
+  
+  
+
+  
+<nav class="govuk-breadcrumbs govuk-!-display-none-print govuk-breadcrumbs--collapse-on-mobile" aria-label="Breadcrumb">
+  <ol class="govuk-breadcrumbs__list">
+
+  
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="#">Digital Prison Services</a>
+    </li>
+  
+
+  
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/">Prepare someone for release</a>
+    </li>
+  
+
+  </ol>
+</nav>
+
+
+
+    <br />
+    
+      <span class="govuk-caption-xl">Prepare someone for release</span>
+      <h1 class="govuk-heading-xl" data-qa="page-heading">Resettlement record</h1>
+    
+
+    
+  <div class="govuk-grid-row profile-header">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+              <a href="/prisoner-overview/?prisonerNumber=A1234DY">
+                <img src="data:image/jpeg;base64, " alt="view prisoner profile"
+                     class="govuk-!-width-full profile-header__person-photo">
+              </a>
+            </div>
+            <div class="govuk-grid-column-three-quarters">
+              <h1 class="govuk-heading-xl" data-qa="profile-heading-full-name">
+                Smith, John
+                <span class="govuk-caption-l">A1234DY</span>
+                <p class="govuk-body-s govuk-!-padding-top-2">
+                  <a href="#/prisoner/A1234DY">View full DPS
+                    profile</a>
+                </p>
+              </h1>
+            </div>
+          </div>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half">
+              <p>
+                <b>Prisoner number:</b><br>
+                A1234DY</p>
+              <p>
+                <b>Location:</b>
+                
+              </p>
+              <p>
+                <b>Date of birth:</b>
+                29 Oct 1991
+                ()</p>
+            </div>
+            <div class="govuk-grid-column-one-half">
+              <p>
+                <b>Release date:</b>
+                30 Nov 2026
+                <br />
+                
+                
+                
+                
+                  (29 days)
+                
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+    
+
+
+  <div class="govuk-grid-row ">
+    <div class="govuk-grid-column-full">
+      <nav class="moj-sub-navigation" aria-label="Sub navigation">
+        <ul class="moj-sub-navigation__list">
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-prisoner-overview"
+                 href="/prisoner-overview/?prisonerNumber=A1234DY" aria-current=page>
+                Resettlement overview
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-accommodation"
+                 href="/accommodation/?prisonerNumber=A1234DY" >
+                Accommodation
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-attitudes-thinking-and-behaviour"
+                 href="/attitudes-thinking-and-behaviour/?prisonerNumber=A1234DY" >
+                Attitudes, thinking and behaviour
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-children-families-and-communities"
+                 href="/children-families-and-communities/?prisonerNumber=A1234DY" >
+                Children, families and communities
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-drugs-and-alcohol"
+                 href="/drugs-and-alcohol/?prisonerNumber=A1234DY" >
+                Drugs and alcohol
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-education-skills-and-work"
+                 href="/education-skills-and-work/?prisonerNumber=A1234DY" >
+                Education, skills and work
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-finance-and-id"
+                 href="/finance-and-id/?prisonerNumber=A1234DY" >
+                Finance and ID
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-health-status"
+                 href="/health-status/?prisonerNumber=A1234DY" >
+                Health
+              </a>
+            </li>
+          
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+
+  </div>
+
+
+    
+      <div class="govuk-width-container">
+        
+        <main class="govuk-main-wrapper app-container govuk-body" id="main-content">
+          
+<div class="govuk-grid-row govuk-!-padding-top-4 govuk-!-padding-bottom-0">
+  
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l" data-qa="page-title-h2">
+      Resettlement overview
+    </h2>
+    
+  </div>
+
+  
+  
+  
+    
+  <div class="govuk-grid-column-one-third">
+    <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
+      <header class="app-summary-card__header">
+        <h3 class="app-summary-card__title">Actions:</h3>
+      </header>
+      <div class="app-summary-card__body">
+        
+          <a href="/resetProfile?prisonerNumber=A1234DY" class="govuk-button" id="reset-profile-btn" track-event-name="ResetReportsAndStatusesLinkClicked" track-event-prisoner-id="A1234DY">
+            Reset reports and support needs
+          </a>
+        
+        
+      </div>
+    </section>
+  </div>
+
+  
+</div>
+
+  <div class="govuk-grid-row govuk-!-padding-top-4">
+    <div class="govuk-grid-column-one-quarter sticky-anchor-links">
+      
+  <ul class="app-subnav__section">
+    <li class="app-subnav__section-item app-subnav__section-item--current">
+      <ul class="app-subnav__section app-subnav__section--nested">
+        
+          <li class="app-subnav__section-item">
+            <a href="#support-needs">Support needs statuses</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#staff-contacts">Staff contacts</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#case-notes">Case notes</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#appointments">Appointments</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#licence-summary">Licence conditions</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#risk-assessments">Risk assessments and predictors</a>
+          </li>
+        
+      </ul>
+    </li>
+  </ul>
+
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      
+        <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
+          <header class="app-summary-card__header">
+            <h3 class="app-summary-card__title">Support needs statuses</h3>
+          </header>
+          <div class="app-summary-card__body">
+            <table class="govuk-table govuk-!-margin-bottom-4">
+              <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Pathway</th>
+                <th scope="col" class="govuk-table__header">Responsible staff</th>
+                <th scope="col" class="govuk-table__header">Support need statuses</th>
+                <th scope="col" class="govuk-table__header">Last updated</th>
+              </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                
+              </tbody>
+            </table>
+          </div>
+        </section>
+      
+
+      
+      
+      <section id="staff-contacts" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Staff contacts
+          </h3>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4">
+          
+            <table class="govuk-table">
+              <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Key worker</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">Steve Rendell</td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Prison Offender Manager</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">David Jones</td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Community Offender Manager</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">John Doe</td>
+              </tr>
+              <tr class="govuk-table__row">
+                  <th class="govuk-table__header" scope="row">Resettlement Worker</th>
+                  <td class="govuk-table__cell govuk-table__cell--min-width-100">Pso Lastname</td>
+              </tr>
+              </tbody>
+            </table>
+          
+          <br>
+        </div>
+      </section>
+      <section id="case-notes" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Case notes<span class="govuk-caption-m">Filtered to Resettlement</span>
+          </h3>
+          
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4">
+          <div class="govuk-grid-row">
+            <form action="/prisoner-overview/#case-notes" method="GET" novalidate>
+              <input name="prisonerNumber" value="A1234DY" hidden />
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="pathway-select">Filter by pathway</label>
+                <select name="selectedPathway" class="govuk-select" id="pathway-select">
+                  <option selected value="All">All pathways</option>
+                  <option  value="ACCOMMODATION">
+                    Accommodation
+                  </option>
+                  <option 
+                          value="ATTITUDES_THINKING_AND_BEHAVIOUR">Attitudes, thinking and behaviour
+                  </option>
+                  <option 
+                          value="CHILDREN_FAMILIES_AND_COMMUNITY">Children, families and communities
+                  </option>
+                  <option  value="DRUGS_AND_ALCOHOL">
+                    Drugs and alcohol
+                  </option>
+                  <option 
+                          value="EDUCATION_SKILLS_AND_WORK">Education, skills and work
+                  </option>
+                  <option  value="FINANCE_AND_ID">Finance
+                    and ID
+                  </option>
+                  <option  value="HEALTH">Health</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="date-range-select">Filter by date range</label>
+                <select name="days" class="govuk-select" id="date-range-select">
+                  <option value="0" selected>All time</option>
+                  <option value="7" >Last week</option>
+                  <option value="30" >Last 4 weeks</option>
+                  <option value="84" >Last 12 weeks</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="sort-by-select">Sort by</label>
+                <select name="sort" class="govuk-select" id="sort-by-select">
+                  <option  value="occurenceDateTime,DESC">
+                    Created (most recent)
+                  </option>
+                  <option  value="pathway,ASC">Pathway</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <button class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-4" type="submit" data-prevent-double-click="true">Apply filters
+                </button>
+              </div>
+            </form>
+          </div>
+          <div class="govuk-grid-row govuk-!-padding-top-8">
+            <div class="govuk-grid-column-full" id="case-notes-container">
+              <hr>
+              
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Support declined.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+    <strong>Resettlement status set to: Support required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          Updating the status to support required.
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+    <strong>Resettlement status set to: Support not required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirecting test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirected to pathway page
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect to individual pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect form to pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test update redirect
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          form submit redirect to pathway
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                
+                
+                
+                
+                
+                  
+  
+  
+
+  <nav class="moj-pagination" aria-label="Pagination navigation">
+    <ul class="moj-pagination__list">
+      
+      
+      
+    </ul>
+    
+    
+      
+    
+    <p class="moj-pagination__results">Showing <b>1</b> to <b></b> of <b></b> results</p>
+  </nav>
+
+                
+              
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="appointments" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Appointments
+            <span class="govuk-caption-m">Post-release appointments</span>
+          </h3>
+          
+        </header>
+        <div class="app-summary-card__body">
+          
+            
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Title</th>
+                  <th scope="col" class="govuk-table__header">Contact</th>
+                  <th scope="col" class="govuk-table__header">Date</th>
+                  <th scope="col" class="govuk-table__header">Time</th>
+                  <th scope="col" class="govuk-table__header">Location</th>
+                </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Appointment with Charity ABC</td>
+                    <td class="govuk-table__cell">Bob Example</td>
+                    <td class="govuk-table__cell">31 Oct 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">SA1 1JG</td>
+                  </tr>
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Appointment with Jobs centre plus</td>
+                    <td class="govuk-table__cell">CRSUATU Staff</td>
+                    <td class="govuk-table__cell">1 Nov 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">Unit 7 Parc Tawe North,
+Swansea,
+SA1 2AA</td>
+                  </tr>
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Accommodation Services - North West</td>
+                    <td class="govuk-table__cell">Not provided</td>
+                    <td class="govuk-table__cell">1 Nov 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">9 Downing Street,
+Gwent,
+S1 2NP</td>
+                  </tr>
+                
+                </tbody>
+              </table>
+            
+          
+          <br>
+        </div>
+      </section>
+
+
+      <section id="licence-summary" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Licence conditions<span class="govuk-caption-m">Data sourced from CVL</span>
+          </h3>
+          <span class="right"></span>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4 govuk-!-padding-left-10">
+          
+            <details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Standard licence conditions
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    
+              <ol class="govuk-list govuk-list--number govuk-list--spaced">
+                
+                  <li>Be of good behaviour and not behave in a way which undermines the purpose of the licence period.
+                    
+                  </li>
+                
+                  <li>Not commit any offence.
+                    
+                  </li>
+                
+                  <li>Keep in touch with the supervising officer in accordance with instructions given by the supervising officer.
+                    
+                  </li>
+                
+              </ol>
+            
+  </div>
+</details>
+
+            
+              <h3 class="govuk-heading-s">Additional and bespoke licence conditions</h3>
+              <ol class="govuk-list govuk-list--number govuk-list--spaced govuk-!-padding-left-6"
+                  start="4">
+                
+                  <li>You must reside overnight within Greater Manchester probation region while of no fixed abode, unless otherwise approved by your supervising officer.
+                    
+                  </li>
+                
+                  <li>Not to enter the area of Leeds City Centre, as defined by the attached map, without the prior approval of your supervising officer.
+                    
+                      <a
+                          href="/licence-image/?licenceId=101&conditionId=1008&prisonerNumber=A1234DY"
+                          rel="noreferrer noopener"
+                          target="_blank">View map (opens in new tab)</a>
+                    
+                  </li>
+                
+                  <li>Report to staff at Victoria Park Probation Centre at 10:30am daily, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a monthly basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.
+                    
+                  </li>
+                
+                  <li>Attend a location, as required by your supervising officer, to give a sample of oral fluid / urine in order to test whether you have any specified Class A and specified Class B drugs in your body, for the purpose of ensuring that you are complying with the condition of your licence requiring you to be of good behaviour. Do not take any action that could hamper or frustrate the drug testing process.
+                    
+                  </li>
+                
+                  <li>Allow person(s) as designated by your supervising officer to install an electronic monitoring tag on you and access to install any associated equipment in your property, and for the purpose of ensuring that equipment is functioning correctly. You must not damage or tamper with these devices and ensure that the tag is charged, and report to your supervising officer and the EM provider immediately if the tag or the associated equipment are not working correctly. This will be for the purpose of monitoring your freedom of movement licence condition(s) unless otherwise authorised by your supervising officer.
+                    
+                  </li>
+                
+                  <li>You will be subject to trail monitoring. Your whereabouts will be electronically monitored by GPS Satellite Tagging, ending on 08 November 2024, and you must cooperate with the monitoring as directed by your supervising officer unless otherwise authorised by your supervising officer.
+                    
+                  </li>
+                
+                  <li>You must let the police search you if they ask. You must also let them search a vehicle you are with, like a car or a motorbike.
+                    
+                  </li>
+                
+              </ol>
+            
+          
+        </div>
+      </section>
+
+    
+      <section id="risk-assessments" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Risk assessments and predictors
+            <span class="govuk-caption-m">Data sourced from Assess Risks and Needs</span>
+          </h3>
+          <span class="right"></span>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4 govuk-!-padding-left-10">
+          <h3>Risk assessments and predictors</h3>
+          
+            <p class="govuk-body-s">Last updated: 29 July 2023</p>
+            <table class="govuk-table">
+              <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      LOW
+                      <span class="govuk-!-font-weight-regular">RSR</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      Low
+                      <span class="govuk-!-font-weight-regular">OGRS3</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      Low
+                      <span class="govuk-!-font-weight-regular">OVP</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__high">
+                      High
+                      <span class="govuk-!-font-weight-regular">OGP</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__medium">
+                      Medium
+                      <span class="govuk-!-font-weight-regular">OSP/I</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__medium">
+                      Medium
+                      <span class="govuk-!-font-weight-regular">OSP/C</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              </tbody>
+            </table>
+          
+          
+          <div class="rosh rosh__high">
+            
+              <h3>
+                
+                  High
+                  <span class="govuk-!-font-weight-regular">RoSH</span>
+                
+              </h3>
+              <p>Risk of serious harm</p>
+              <p class="govuk-body-s">Last updated: 29 July 2023</p>
+              <table class="govuk-table">
+                <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                  <th scope="row" class="govuk-table__header">
+                    Risk to
+                  </th>
+                  <td class="govuk-table__cell">
+                    <br />
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Children
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Public
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Known adult
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Staff
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__medium">
+                        Medium
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Prisoners
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__low">
+                        Low
+                      </strong>
+                    
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            
+          </div>
+          <div class="mappa-section">
+            
+              <h3>
+                CAT3 / LEVEL1
+                <span class="govuk-!-font-weight-regular">MAPPA</span>
+              </h3>
+              <p>Multi-agency public protection Arrangements</p>
+              <p class="govuk-body-s">Last updated: 27 January 2023</p>
+            
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+        </main>
+      </div>
+    
+
+    
+  
+    
+    <footer class="govuk-footer govuk-!-display-none-print"></footer>
+
+  
+
+
+    
+  
+  
+  <script type="module" src="/assets/govukFrontendInit.js"></script>
+  <script src="/assets/moj/all.js"></script>
+  <script src="/assets/mojFrontendInit.js"></script>
+
+
+  </body>
+</html>
+"
+`;
+
+exports[`prisonerOverview should display "reset profile" button and other tasks when readOnlyMode is false and tasksView is true 1`] = `
+"<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8">
+    <title>Prepare someone for release - Resettlement overview
+</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+
+    
+      <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
+      <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/assets/manifest.json">
+    
+
+    
+  <link href="/assets/stylesheets/application.css?" rel="stylesheet" />
+  <script src="/assets/js/jquery.min.js"></script>
+  
+  <!--<![endif]-->
+  
+  
+  <script src="/assets/analytics.js" nonce=""></script>
+  <meta name="csrf-token" content="">
+
+    
+  </head>
+  <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    
+
+    
+      <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+    
+
+    
+  
+    
+    
+<header class="fallback-dps-header" role="banner">
+  <div class="fallback-dps-header__container">
+    <div class="fallback-dps-header__title">
+      <a class="fallback-dps-header__link fallback-dps-header__link--no-underline fallback-dps-header__title__service-name" href="#">
+        <svg role="presentation" focusable="false" class="fallback-dps-header__logo" xmlns="http://www.w3.org/2000/svg" width="41" height="30" viewBox="0 0 41 30">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M7.54677 9.20065C8.64351 9.65301 9.88802 9.13584 10.3347 8.05183C10.7839 6.97073 10.27 5.71374 9.17342 5.26352C8.09836 4.82212 6.84843 5.34938 6.40124 6.4349C5.95404 7.515 6.47121 8.76014 7.54677 9.20065Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M2.71865 12.0298C3.81564 12.4821 5.0599 11.965 5.50659 10.881C5.9558 9.79984 5.44191 8.54286 4.34529 8.09264C3.27023 7.65124 2.02031 8.17837 1.57311 9.26402C1.12592 10.3441 1.64308 11.5891 2.71865 12.0298Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M1.3065 17.397C2.4035 17.8494 3.648 17.3322 4.09469 16.2481C4.54391 15.1669 4.02977 13.91 2.9334 13.4599C1.85834 13.0183 0.608415 13.5457 0.160968 14.6311C-0.286227 15.7112 0.231192 16.9565 1.3065 17.397Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M12.9335 10.9018C14.0302 11.3542 15.2747 10.837 15.7214 9.75301C16.1706 8.6719 15.6568 7.41491 14.5601 6.96469C13.4851 6.52329 12.2351 7.05055 11.788 8.13607C11.3408 9.21617 11.8579 10.4613 12.9335 10.9018Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M32.4543 9.20065C31.3573 9.65301 30.1131 9.13584 29.6661 8.05183C29.2172 6.97073 29.7308 5.71374 30.8274 5.26352C31.9027 4.82212 33.1527 5.34938 33.5999 6.4349C34.0471 7.515 33.5299 8.76014 32.4543 9.20065Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M37.2805 12.0298C36.1833 12.4821 34.939 11.965 34.4923 10.881C34.0433 9.79984 34.557 8.54286 35.6536 8.09264C36.7289 7.65124 37.9788 8.17837 38.426 9.26402C38.8732 10.3441 38.3558 11.5891 37.2805 12.0298Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M38.6944 17.397C37.5977 17.8494 36.3532 17.3322 35.9065 16.2481C35.4573 15.1669 35.9712 13.91 37.0678 13.4599C38.1428 13.0183 39.3928 13.5457 39.84 14.6311C40.2874 15.7112 39.77 16.9565 38.6944 17.397Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M27.0657 10.9018C25.9687 11.3542 24.7244 10.837 24.2775 9.75301C23.8285 8.6719 24.3421 7.41491 25.4388 6.96469C26.5141 6.52329 27.764 7.05055 28.2112 8.13607C28.6584 9.21617 28.1412 10.4613 27.0657 10.9018Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M21.1246 5.39912L21.1311 5.39294L23.8259 6.80828V2.83635L21.1342 3.68851L21.1266 3.68044C21.0512 3.58147 20.9639 3.49284 20.8653 3.41656L20.858 3.40899L21.9407 0L19.9961 0.000252154L18.0507 0L19.1337 3.40899L19.1263 3.41656C19.0281 3.49284 18.9402 3.58147 18.8653 3.68044L18.8573 3.68851L16.166 2.83635V6.80828L18.8609 5.39294L18.8673 5.39912C18.9471 5.50351 19.0407 5.5963 19.1458 5.67498L17.5981 10.344C17.5962 10.3498 17.5942 10.3556 17.5925 10.3611L17.5908 10.366L17.5913 10.3666C17.5193 10.5997 17.4807 10.847 17.4807 11.1036C17.4807 12.3669 18.4127 13.4095 19.6264 13.5887C19.6445 13.5915 19.6621 13.5946 19.6804 13.5968C19.7838 13.61 19.8884 13.6188 19.9956 13.6188H19.9961H19.9964C20.1031 13.6188 20.2079 13.61 20.3116 13.5968C20.3295 13.5946 20.3472 13.5915 20.3655 13.5887C21.5788 13.4095 22.5112 12.3669 22.5112 11.1036C22.5112 10.847 22.4721 10.5997 22.4006 10.3666L22.4009 10.366L22.3994 10.3611C22.3975 10.3556 22.3955 10.3498 22.3935 10.344L20.8461 5.67498C20.951 5.5963 21.0448 5.50351 21.1246 5.39912Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M19.9961 28.2469C25.1126 28.2469 29.9557 28.5936 34.2707 29.2111C35.4958 24.0612 36.9865 21.1103 38.5258 19.0092L35.6272 17.978C35.9156 19.4496 35.9616 20.1346 35.6388 21.0806C35.1608 20.6133 34.7078 19.7539 34.3542 18.4405L32.95 23.1175C33.8045 22.529 34.4635 22.1489 35.2174 22.1306C33.8799 25.0107 32.2103 25.7519 31.1284 25.552C29.8069 25.3094 29.1998 24.1313 29.4046 23.1324C29.7085 21.7159 31.1616 21.3468 31.8404 22.994C33.1384 20.3461 30.9362 19.5212 29.5189 20.3045C31.6957 18.1333 31.9448 16.2036 30.1877 13.8682C27.7395 15.7394 27.7109 17.5926 28.8127 20.1999C27.383 18.5638 25.1586 19.4422 25.9621 22.0859C26.9932 20.4897 28.3578 21.4937 28.1436 23.0095C27.9627 24.3308 26.2183 25.3978 24.0464 25.2087C20.9338 24.9265 20.7484 22.7785 20.6709 21.0011C21.4362 20.8593 22.814 21.5684 23.9887 23.2183L24.4217 18.2575C23.1434 19.5894 21.9821 19.8421 20.6921 19.8829C21.1215 18.5433 23.0951 16.3481 23.0951 16.3481L20.2276 16.3478H20.2261H20.2248L16.9033 16.3481C16.9033 16.3481 18.877 18.5433 19.3061 19.8829C18.0163 19.8421 16.8551 19.5894 15.5765 18.2575L16.0097 23.2183C17.1847 21.5684 18.5623 20.8593 19.3276 21.0011C19.2503 22.7785 19.0648 24.9265 15.9521 25.2087C13.7802 25.3978 12.036 24.3308 11.8548 23.0095C11.6406 21.4937 13.0053 20.4897 14.0365 22.0859C14.8401 19.4422 12.6152 18.5638 11.186 20.1999C12.2877 17.5926 12.2587 15.7394 9.81076 13.8682C8.0535 16.2036 8.3025 18.1333 10.4793 20.3045C9.06211 19.5212 6.86005 20.3461 8.15814 22.994C8.83681 21.3468 10.2902 21.7159 10.5941 23.1324C10.7989 24.1313 10.1911 25.3094 8.87035 25.552C7.78836 25.7519 6.11859 25.0107 4.78117 22.1306C5.53523 22.1489 6.19361 22.529 7.04866 23.1175L5.64454 18.4405C5.29039 19.7539 4.8379 20.6133 4.35969 21.0806C4.03656 20.1346 4.08283 19.4496 4.37091 17.978L1.47266 19.0092C3.01218 21.11 4.50241 24.0607 5.72725 29.21C10.041 28.5931 14.8817 28.2469 19.9961 28.2469Z"/>
+        </svg>
+        Digital Prison Services
+      </a>
+
+      
+    </div>
+
+    <nav aria-label="Account navigation">
+      <ul class="fallback-dps-header__navigation">
+        
+          <li class="fallback-dps-header__navigation__item">
+            <span data-qa=header-user-name>F. Last</span>
+          </li>
+        
+
+        <li class="fallback-dps-header__navigation__item">
+          <a data-qa="signOut" class="fallback-dps-header__link fallback-dps-header__link--no-underline fallback-dps-header__sign-out" href="/sign-out">Sign out</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+  
+
+  <div class="govuk-width-container">
+    
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      BETA
+    </strong>
+    <span class="govuk-phase-banner__text">
+      This is a new service – your <a class="govuk-link" target="_blank" rel="noopener noreferrer"
+                                                            href="https://www.smartsurvey.co.uk/s/QQV2UP">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>
+
+    
+      
+    
+    
+      
+      
+    
+
+    
+  
+  
+
+  
+<nav class="govuk-breadcrumbs govuk-!-display-none-print govuk-breadcrumbs--collapse-on-mobile" aria-label="Breadcrumb">
+  <ol class="govuk-breadcrumbs__list">
+
+  
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="#">Digital Prison Services</a>
+    </li>
+  
+
+  
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/">Prepare someone for release</a>
+    </li>
+  
+
+  </ol>
+</nav>
+
+
+
+    <br />
+    
+      <span class="govuk-caption-xl">Prepare someone for release</span>
+      <h1 class="govuk-heading-xl" data-qa="page-heading">Resettlement record</h1>
+    
+
+    
+  <div class="govuk-grid-row profile-header">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+              <a href="/prisoner-overview/?prisonerNumber=A1234DY">
+                <img src="data:image/jpeg;base64, " alt="view prisoner profile"
+                     class="govuk-!-width-full profile-header__person-photo">
+              </a>
+            </div>
+            <div class="govuk-grid-column-three-quarters">
+              <h1 class="govuk-heading-xl" data-qa="profile-heading-full-name">
+                Smith, John
+                <span class="govuk-caption-l">A1234DY</span>
+                <p class="govuk-body-s govuk-!-padding-top-2">
+                  <a href="#/prisoner/A1234DY">View full DPS
+                    profile</a>
+                </p>
+              </h1>
+            </div>
+          </div>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half">
+              <p>
+                <b>Prisoner number:</b><br>
+                A1234DY</p>
+              <p>
+                <b>Location:</b>
+                
+              </p>
+              <p>
+                <b>Date of birth:</b>
+                29 Oct 1991
+                ()</p>
+            </div>
+            <div class="govuk-grid-column-one-half">
+              <p>
+                <b>Release date:</b>
+                30 Nov 2026
+                <br />
+                
+                
+                
+                
+                  (29 days)
+                
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+    
+
+
+  <div class="govuk-grid-row ">
+    <div class="govuk-grid-column-full">
+      <nav class="moj-sub-navigation" aria-label="Sub navigation">
+        <ul class="moj-sub-navigation__list">
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-prisoner-overview"
+                 href="/prisoner-overview/?prisonerNumber=A1234DY" aria-current=page>
+                Resettlement overview
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-accommodation"
+                 href="/accommodation/?prisonerNumber=A1234DY" >
+                Accommodation
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-attitudes-thinking-and-behaviour"
+                 href="/attitudes-thinking-and-behaviour/?prisonerNumber=A1234DY" >
+                Attitudes, thinking and behaviour
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-children-families-and-communities"
+                 href="/children-families-and-communities/?prisonerNumber=A1234DY" >
+                Children, families and communities
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-drugs-and-alcohol"
+                 href="/drugs-and-alcohol/?prisonerNumber=A1234DY" >
+                Drugs and alcohol
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-education-skills-and-work"
+                 href="/education-skills-and-work/?prisonerNumber=A1234DY" >
+                Education, skills and work
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-finance-and-id"
+                 href="/finance-and-id/?prisonerNumber=A1234DY" >
+                Finance and ID
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-health-status"
+                 href="/health-status/?prisonerNumber=A1234DY" >
+                Health
+              </a>
+            </li>
+          
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+
+  </div>
+
+
+    
+      <div class="govuk-width-container">
+        
+        <main class="govuk-main-wrapper app-container govuk-body" id="main-content">
+          
+<div class="govuk-grid-row govuk-!-padding-top-4 govuk-!-padding-bottom-0">
+  
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l" data-qa="page-title-h2">
+      Resettlement overview
+    </h2>
+    
+  </div>
+
+  
+  
+  
+    
+  <div class="govuk-grid-column-one-third">
+    <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
+      <header class="app-summary-card__header">
+        <h3 class="app-summary-card__title">Actions:</h3>
+      </header>
+      <div class="app-summary-card__body">
+        
+          <a href="/resetProfile?prisonerNumber=A1234DY" class="govuk-button" id="reset-profile-btn" track-event-name="ResetReportsAndStatusesLinkClicked" track-event-prisoner-id="A1234DY">
+            Reset reports and support needs
+          </a>
+        
+        
+          <div class="govuk-form-group govuk-!-margin-0">
+            <input type="hidden" id="updated" name="updated" value="today">
+            <input type="hidden" id="pathway" name="pathway" value="attitudes">
+            <a id="generate-pdf-task-btn"  class="govuk-button govuk-button--primary" href="/print/packPdf?prisonerNumber=A1234DY" target="_blank">
+              Plan Your Future pack PDF
+            </a>
+          </div>
+          <div class="govuk-form-group govuk-!-margin-0">
+            <a id="generate-otp-task-btn" class="govuk-button govuk-button--primary" href="/print/otp?prisonerNumber=A1234DY">
+              Generate First-time ID code
+            </a>
+          </div>
+        
+      </div>
+    </section>
+  </div>
+
+  
+</div>
+
+  <div class="govuk-grid-row govuk-!-padding-top-4">
+    <div class="govuk-grid-column-one-quarter sticky-anchor-links">
+      
+  <ul class="app-subnav__section">
+    <li class="app-subnav__section-item app-subnav__section-item--current">
+      <ul class="app-subnav__section app-subnav__section--nested">
+        
+          <li class="app-subnav__section-item">
+            <a href="#support-needs">Support needs statuses</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#staff-contacts">Staff contacts</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#case-notes">Case notes</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#appointments">Appointments</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#licence-summary">Licence conditions</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#risk-assessments">Risk assessments and predictors</a>
+          </li>
+        
+      </ul>
+    </li>
+  </ul>
+
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      
+        <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
+          <header class="app-summary-card__header">
+            <h3 class="app-summary-card__title">Support needs statuses</h3>
+          </header>
+          <div class="app-summary-card__body">
+            <table class="govuk-table govuk-!-margin-bottom-4">
+              <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Pathway</th>
+                <th scope="col" class="govuk-table__header">Responsible staff</th>
+                <th scope="col" class="govuk-table__header">Support need statuses</th>
+                <th scope="col" class="govuk-table__header">Last updated</th>
+              </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                
+              </tbody>
+            </table>
+          </div>
+        </section>
+      
+
+      
+      
+      <section id="staff-contacts" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Staff contacts
+          </h3>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4">
+          
+            <table class="govuk-table">
+              <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Key worker</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">Steve Rendell</td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Prison Offender Manager</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">David Jones</td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Community Offender Manager</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">John Doe</td>
+              </tr>
+              <tr class="govuk-table__row">
+                  <th class="govuk-table__header" scope="row">Resettlement Worker</th>
+                  <td class="govuk-table__cell govuk-table__cell--min-width-100">Pso Lastname</td>
+              </tr>
+              </tbody>
+            </table>
+          
+          <br>
+        </div>
+      </section>
+      <section id="case-notes" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Case notes<span class="govuk-caption-m">Filtered to Resettlement</span>
+          </h3>
+          
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4">
+          <div class="govuk-grid-row">
+            <form action="/prisoner-overview/#case-notes" method="GET" novalidate>
+              <input name="prisonerNumber" value="A1234DY" hidden />
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="pathway-select">Filter by pathway</label>
+                <select name="selectedPathway" class="govuk-select" id="pathway-select">
+                  <option selected value="All">All pathways</option>
+                  <option  value="ACCOMMODATION">
+                    Accommodation
+                  </option>
+                  <option 
+                          value="ATTITUDES_THINKING_AND_BEHAVIOUR">Attitudes, thinking and behaviour
+                  </option>
+                  <option 
+                          value="CHILDREN_FAMILIES_AND_COMMUNITY">Children, families and communities
+                  </option>
+                  <option  value="DRUGS_AND_ALCOHOL">
+                    Drugs and alcohol
+                  </option>
+                  <option 
+                          value="EDUCATION_SKILLS_AND_WORK">Education, skills and work
+                  </option>
+                  <option  value="FINANCE_AND_ID">Finance
+                    and ID
+                  </option>
+                  <option  value="HEALTH">Health</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="date-range-select">Filter by date range</label>
+                <select name="days" class="govuk-select" id="date-range-select">
+                  <option value="0" selected>All time</option>
+                  <option value="7" >Last week</option>
+                  <option value="30" >Last 4 weeks</option>
+                  <option value="84" >Last 12 weeks</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="sort-by-select">Sort by</label>
+                <select name="sort" class="govuk-select" id="sort-by-select">
+                  <option  value="occurenceDateTime,DESC">
+                    Created (most recent)
+                  </option>
+                  <option  value="pathway,ASC">Pathway</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <button class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-4" type="submit" data-prevent-double-click="true">Apply filters
+                </button>
+              </div>
+            </form>
+          </div>
+          <div class="govuk-grid-row govuk-!-padding-top-8">
+            <div class="govuk-grid-column-full" id="case-notes-container">
+              <hr>
+              
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Support declined.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+    <strong>Resettlement status set to: Support required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          Updating the status to support required.
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+    <strong>Resettlement status set to: Support not required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirecting test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirected to pathway page
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect to individual pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect form to pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test update redirect
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          form submit redirect to pathway
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                
+                
+                
+                
+                
+                  
+  
+  
+
+  <nav class="moj-pagination" aria-label="Pagination navigation">
+    <ul class="moj-pagination__list">
+      
+      
+      
+    </ul>
+    
+    
+      
+    
+    <p class="moj-pagination__results">Showing <b>1</b> to <b></b> of <b></b> results</p>
+  </nav>
+
+                
+              
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="appointments" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Appointments
+            <span class="govuk-caption-m">Post-release appointments</span>
+          </h3>
+          
+        </header>
+        <div class="app-summary-card__body">
+          
+            
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Title</th>
+                  <th scope="col" class="govuk-table__header">Contact</th>
+                  <th scope="col" class="govuk-table__header">Date</th>
+                  <th scope="col" class="govuk-table__header">Time</th>
+                  <th scope="col" class="govuk-table__header">Location</th>
+                </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Appointment with Charity ABC</td>
+                    <td class="govuk-table__cell">Bob Example</td>
+                    <td class="govuk-table__cell">31 Oct 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">SA1 1JG</td>
+                  </tr>
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Appointment with Jobs centre plus</td>
+                    <td class="govuk-table__cell">CRSUATU Staff</td>
+                    <td class="govuk-table__cell">1 Nov 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">Unit 7 Parc Tawe North,
+Swansea,
+SA1 2AA</td>
+                  </tr>
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Accommodation Services - North West</td>
+                    <td class="govuk-table__cell">Not provided</td>
+                    <td class="govuk-table__cell">1 Nov 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">9 Downing Street,
+Gwent,
+S1 2NP</td>
+                  </tr>
+                
+                </tbody>
+              </table>
+            
+          
+          <br>
+        </div>
+      </section>
+
+
+      <section id="licence-summary" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Licence conditions<span class="govuk-caption-m">Data sourced from CVL</span>
+          </h3>
+          <span class="right"></span>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4 govuk-!-padding-left-10">
+          
+            <details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Standard licence conditions
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    
+              <ol class="govuk-list govuk-list--number govuk-list--spaced">
+                
+                  <li>Be of good behaviour and not behave in a way which undermines the purpose of the licence period.
+                    
+                  </li>
+                
+                  <li>Not commit any offence.
+                    
+                  </li>
+                
+                  <li>Keep in touch with the supervising officer in accordance with instructions given by the supervising officer.
+                    
+                  </li>
+                
+              </ol>
+            
+  </div>
+</details>
+
+            
+              <h3 class="govuk-heading-s">Additional and bespoke licence conditions</h3>
+              <ol class="govuk-list govuk-list--number govuk-list--spaced govuk-!-padding-left-6"
+                  start="4">
+                
+                  <li>You must reside overnight within Greater Manchester probation region while of no fixed abode, unless otherwise approved by your supervising officer.
+                    
+                  </li>
+                
+                  <li>Not to enter the area of Leeds City Centre, as defined by the attached map, without the prior approval of your supervising officer.
+                    
+                      <a
+                          href="/licence-image/?licenceId=101&conditionId=1008&prisonerNumber=A1234DY"
+                          rel="noreferrer noopener"
+                          target="_blank">View map (opens in new tab)</a>
+                    
+                  </li>
+                
+                  <li>Report to staff at Victoria Park Probation Centre at 10:30am daily, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a monthly basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.
+                    
+                  </li>
+                
+                  <li>Attend a location, as required by your supervising officer, to give a sample of oral fluid / urine in order to test whether you have any specified Class A and specified Class B drugs in your body, for the purpose of ensuring that you are complying with the condition of your licence requiring you to be of good behaviour. Do not take any action that could hamper or frustrate the drug testing process.
+                    
+                  </li>
+                
+                  <li>Allow person(s) as designated by your supervising officer to install an electronic monitoring tag on you and access to install any associated equipment in your property, and for the purpose of ensuring that equipment is functioning correctly. You must not damage or tamper with these devices and ensure that the tag is charged, and report to your supervising officer and the EM provider immediately if the tag or the associated equipment are not working correctly. This will be for the purpose of monitoring your freedom of movement licence condition(s) unless otherwise authorised by your supervising officer.
+                    
+                  </li>
+                
+                  <li>You will be subject to trail monitoring. Your whereabouts will be electronically monitored by GPS Satellite Tagging, ending on 08 November 2024, and you must cooperate with the monitoring as directed by your supervising officer unless otherwise authorised by your supervising officer.
+                    
+                  </li>
+                
+                  <li>You must let the police search you if they ask. You must also let them search a vehicle you are with, like a car or a motorbike.
+                    
+                  </li>
+                
+              </ol>
+            
+          
+        </div>
+      </section>
+
+    
+      <section id="risk-assessments" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Risk assessments and predictors
+            <span class="govuk-caption-m">Data sourced from Assess Risks and Needs</span>
+          </h3>
+          <span class="right"></span>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4 govuk-!-padding-left-10">
+          <h3>Risk assessments and predictors</h3>
+          
+            <p class="govuk-body-s">Last updated: 29 July 2023</p>
+            <table class="govuk-table">
+              <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      LOW
+                      <span class="govuk-!-font-weight-regular">RSR</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      Low
+                      <span class="govuk-!-font-weight-regular">OGRS3</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      Low
+                      <span class="govuk-!-font-weight-regular">OVP</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__high">
+                      High
+                      <span class="govuk-!-font-weight-regular">OGP</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__medium">
+                      Medium
+                      <span class="govuk-!-font-weight-regular">OSP/I</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__medium">
+                      Medium
+                      <span class="govuk-!-font-weight-regular">OSP/C</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              </tbody>
+            </table>
+          
+          
+          <div class="rosh rosh__high">
+            
+              <h3>
+                
+                  High
+                  <span class="govuk-!-font-weight-regular">RoSH</span>
+                
+              </h3>
+              <p>Risk of serious harm</p>
+              <p class="govuk-body-s">Last updated: 29 July 2023</p>
+              <table class="govuk-table">
+                <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                  <th scope="row" class="govuk-table__header">
+                    Risk to
+                  </th>
+                  <td class="govuk-table__cell">
+                    <br />
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Children
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Public
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Known adult
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Staff
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__medium">
+                        Medium
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Prisoners
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__low">
+                        Low
+                      </strong>
+                    
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            
+          </div>
+          <div class="mappa-section">
+            
+              <h3>
+                CAT3 / LEVEL1
+                <span class="govuk-!-font-weight-regular">MAPPA</span>
+              </h3>
+              <p>Multi-agency public protection Arrangements</p>
+              <p class="govuk-body-s">Last updated: 27 January 2023</p>
+            
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+        </main>
+      </div>
+    
+
+    
+  
+    
+    <footer class="govuk-footer govuk-!-display-none-print"></footer>
+
+  
+
+
+    
+  
+  
+  <script type="module" src="/assets/govukFrontendInit.js"></script>
+  <script src="/assets/moj/all.js"></script>
+  <script src="/assets/mojFrontendInit.js"></script>
+
+
+  </body>
+</html>
+"
+`;
+
+exports[`prisonerOverview should display NO "Action" box when readOnlyMode is true and tasksView is false 1`] = `
+"<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8">
+    <title>Prepare someone for release - Resettlement overview
+</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+
+    
+      <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
+      <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/assets/manifest.json">
+    
+
+    
+  <link href="/assets/stylesheets/application.css?" rel="stylesheet" />
+  <script src="/assets/js/jquery.min.js"></script>
+  
+  <!--<![endif]-->
+  
+  
+  <script src="/assets/analytics.js" nonce=""></script>
+  <meta name="csrf-token" content="">
+
+    
+  </head>
+  <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    
+
+    
+      <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+    
+
+    
+  
+    
+    
+<header class="fallback-dps-header" role="banner">
+  <div class="fallback-dps-header__container">
+    <div class="fallback-dps-header__title">
+      <a class="fallback-dps-header__link fallback-dps-header__link--no-underline fallback-dps-header__title__service-name" href="#">
+        <svg role="presentation" focusable="false" class="fallback-dps-header__logo" xmlns="http://www.w3.org/2000/svg" width="41" height="30" viewBox="0 0 41 30">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M7.54677 9.20065C8.64351 9.65301 9.88802 9.13584 10.3347 8.05183C10.7839 6.97073 10.27 5.71374 9.17342 5.26352C8.09836 4.82212 6.84843 5.34938 6.40124 6.4349C5.95404 7.515 6.47121 8.76014 7.54677 9.20065Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M2.71865 12.0298C3.81564 12.4821 5.0599 11.965 5.50659 10.881C5.9558 9.79984 5.44191 8.54286 4.34529 8.09264C3.27023 7.65124 2.02031 8.17837 1.57311 9.26402C1.12592 10.3441 1.64308 11.5891 2.71865 12.0298Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M1.3065 17.397C2.4035 17.8494 3.648 17.3322 4.09469 16.2481C4.54391 15.1669 4.02977 13.91 2.9334 13.4599C1.85834 13.0183 0.608415 13.5457 0.160968 14.6311C-0.286227 15.7112 0.231192 16.9565 1.3065 17.397Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M12.9335 10.9018C14.0302 11.3542 15.2747 10.837 15.7214 9.75301C16.1706 8.6719 15.6568 7.41491 14.5601 6.96469C13.4851 6.52329 12.2351 7.05055 11.788 8.13607C11.3408 9.21617 11.8579 10.4613 12.9335 10.9018Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M32.4543 9.20065C31.3573 9.65301 30.1131 9.13584 29.6661 8.05183C29.2172 6.97073 29.7308 5.71374 30.8274 5.26352C31.9027 4.82212 33.1527 5.34938 33.5999 6.4349C34.0471 7.515 33.5299 8.76014 32.4543 9.20065Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M37.2805 12.0298C36.1833 12.4821 34.939 11.965 34.4923 10.881C34.0433 9.79984 34.557 8.54286 35.6536 8.09264C36.7289 7.65124 37.9788 8.17837 38.426 9.26402C38.8732 10.3441 38.3558 11.5891 37.2805 12.0298Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M38.6944 17.397C37.5977 17.8494 36.3532 17.3322 35.9065 16.2481C35.4573 15.1669 35.9712 13.91 37.0678 13.4599C38.1428 13.0183 39.3928 13.5457 39.84 14.6311C40.2874 15.7112 39.77 16.9565 38.6944 17.397Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M27.0657 10.9018C25.9687 11.3542 24.7244 10.837 24.2775 9.75301C23.8285 8.6719 24.3421 7.41491 25.4388 6.96469C26.5141 6.52329 27.764 7.05055 28.2112 8.13607C28.6584 9.21617 28.1412 10.4613 27.0657 10.9018Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M21.1246 5.39912L21.1311 5.39294L23.8259 6.80828V2.83635L21.1342 3.68851L21.1266 3.68044C21.0512 3.58147 20.9639 3.49284 20.8653 3.41656L20.858 3.40899L21.9407 0L19.9961 0.000252154L18.0507 0L19.1337 3.40899L19.1263 3.41656C19.0281 3.49284 18.9402 3.58147 18.8653 3.68044L18.8573 3.68851L16.166 2.83635V6.80828L18.8609 5.39294L18.8673 5.39912C18.9471 5.50351 19.0407 5.5963 19.1458 5.67498L17.5981 10.344C17.5962 10.3498 17.5942 10.3556 17.5925 10.3611L17.5908 10.366L17.5913 10.3666C17.5193 10.5997 17.4807 10.847 17.4807 11.1036C17.4807 12.3669 18.4127 13.4095 19.6264 13.5887C19.6445 13.5915 19.6621 13.5946 19.6804 13.5968C19.7838 13.61 19.8884 13.6188 19.9956 13.6188H19.9961H19.9964C20.1031 13.6188 20.2079 13.61 20.3116 13.5968C20.3295 13.5946 20.3472 13.5915 20.3655 13.5887C21.5788 13.4095 22.5112 12.3669 22.5112 11.1036C22.5112 10.847 22.4721 10.5997 22.4006 10.3666L22.4009 10.366L22.3994 10.3611C22.3975 10.3556 22.3955 10.3498 22.3935 10.344L20.8461 5.67498C20.951 5.5963 21.0448 5.50351 21.1246 5.39912Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M19.9961 28.2469C25.1126 28.2469 29.9557 28.5936 34.2707 29.2111C35.4958 24.0612 36.9865 21.1103 38.5258 19.0092L35.6272 17.978C35.9156 19.4496 35.9616 20.1346 35.6388 21.0806C35.1608 20.6133 34.7078 19.7539 34.3542 18.4405L32.95 23.1175C33.8045 22.529 34.4635 22.1489 35.2174 22.1306C33.8799 25.0107 32.2103 25.7519 31.1284 25.552C29.8069 25.3094 29.1998 24.1313 29.4046 23.1324C29.7085 21.7159 31.1616 21.3468 31.8404 22.994C33.1384 20.3461 30.9362 19.5212 29.5189 20.3045C31.6957 18.1333 31.9448 16.2036 30.1877 13.8682C27.7395 15.7394 27.7109 17.5926 28.8127 20.1999C27.383 18.5638 25.1586 19.4422 25.9621 22.0859C26.9932 20.4897 28.3578 21.4937 28.1436 23.0095C27.9627 24.3308 26.2183 25.3978 24.0464 25.2087C20.9338 24.9265 20.7484 22.7785 20.6709 21.0011C21.4362 20.8593 22.814 21.5684 23.9887 23.2183L24.4217 18.2575C23.1434 19.5894 21.9821 19.8421 20.6921 19.8829C21.1215 18.5433 23.0951 16.3481 23.0951 16.3481L20.2276 16.3478H20.2261H20.2248L16.9033 16.3481C16.9033 16.3481 18.877 18.5433 19.3061 19.8829C18.0163 19.8421 16.8551 19.5894 15.5765 18.2575L16.0097 23.2183C17.1847 21.5684 18.5623 20.8593 19.3276 21.0011C19.2503 22.7785 19.0648 24.9265 15.9521 25.2087C13.7802 25.3978 12.036 24.3308 11.8548 23.0095C11.6406 21.4937 13.0053 20.4897 14.0365 22.0859C14.8401 19.4422 12.6152 18.5638 11.186 20.1999C12.2877 17.5926 12.2587 15.7394 9.81076 13.8682C8.0535 16.2036 8.3025 18.1333 10.4793 20.3045C9.06211 19.5212 6.86005 20.3461 8.15814 22.994C8.83681 21.3468 10.2902 21.7159 10.5941 23.1324C10.7989 24.1313 10.1911 25.3094 8.87035 25.552C7.78836 25.7519 6.11859 25.0107 4.78117 22.1306C5.53523 22.1489 6.19361 22.529 7.04866 23.1175L5.64454 18.4405C5.29039 19.7539 4.8379 20.6133 4.35969 21.0806C4.03656 20.1346 4.08283 19.4496 4.37091 17.978L1.47266 19.0092C3.01218 21.11 4.50241 24.0607 5.72725 29.21C10.041 28.5931 14.8817 28.2469 19.9961 28.2469Z"/>
+        </svg>
+        Digital Prison Services
+      </a>
+
+      
+    </div>
+
+    <nav aria-label="Account navigation">
+      <ul class="fallback-dps-header__navigation">
+        
+          <li class="fallback-dps-header__navigation__item">
+            <span data-qa=header-user-name>F. Last</span>
+          </li>
+        
+
+        <li class="fallback-dps-header__navigation__item">
+          <a data-qa="signOut" class="fallback-dps-header__link fallback-dps-header__link--no-underline fallback-dps-header__sign-out" href="/sign-out">Sign out</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+  
+
+  <div class="govuk-width-container">
+    
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      BETA
+    </strong>
+    <span class="govuk-phase-banner__text">
+      This is a new service – your <a class="govuk-link" target="_blank" rel="noopener noreferrer"
+                                                            href="https://www.smartsurvey.co.uk/s/QQV2UP">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>
+
+    
+      
+    
+    
+      
+      
+    
+
+    
+  
+  
+
+  
+<nav class="govuk-breadcrumbs govuk-!-display-none-print govuk-breadcrumbs--collapse-on-mobile" aria-label="Breadcrumb">
+  <ol class="govuk-breadcrumbs__list">
+
+  
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="#">Digital Prison Services</a>
+    </li>
+  
+
+  
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/">Prepare someone for release</a>
+    </li>
+  
+
+  </ol>
+</nav>
+
+
+
+    <br />
+    
+      <span class="govuk-caption-xl">Prepare someone for release</span>
+      <h1 class="govuk-heading-xl" data-qa="page-heading">Resettlement record</h1>
+    
+
+    
+  <div class="govuk-grid-row profile-header">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+              <a href="/prisoner-overview/?prisonerNumber=A1234DY">
+                <img src="data:image/jpeg;base64, " alt="view prisoner profile"
+                     class="govuk-!-width-full profile-header__person-photo">
+              </a>
+            </div>
+            <div class="govuk-grid-column-three-quarters">
+              <h1 class="govuk-heading-xl" data-qa="profile-heading-full-name">
+                Smith, John
+                <span class="govuk-caption-l">A1234DY</span>
+                <p class="govuk-body-s govuk-!-padding-top-2">
+                  <a href="#/prisoner/A1234DY">View full DPS
+                    profile</a>
+                </p>
+              </h1>
+            </div>
+          </div>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half">
+              <p>
+                <b>Prisoner number:</b><br>
+                A1234DY</p>
+              <p>
+                <b>Location:</b>
+                
+              </p>
+              <p>
+                <b>Date of birth:</b>
+                29 Oct 1991
+                ()</p>
+            </div>
+            <div class="govuk-grid-column-one-half">
+              <p>
+                <b>Release date:</b>
+                30 Nov 2026
+                <br />
+                
+                
+                
+                
+                  (29 days)
+                
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+    
+
+
+  <div class="govuk-grid-row ">
+    <div class="govuk-grid-column-full">
+      <nav class="moj-sub-navigation" aria-label="Sub navigation">
+        <ul class="moj-sub-navigation__list">
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-prisoner-overview"
+                 href="/prisoner-overview/?prisonerNumber=A1234DY" aria-current=page>
+                Resettlement overview
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-accommodation"
+                 href="/accommodation/?prisonerNumber=A1234DY" >
+                Accommodation
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-attitudes-thinking-and-behaviour"
+                 href="/attitudes-thinking-and-behaviour/?prisonerNumber=A1234DY" >
+                Attitudes, thinking and behaviour
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-children-families-and-communities"
+                 href="/children-families-and-communities/?prisonerNumber=A1234DY" >
+                Children, families and communities
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-drugs-and-alcohol"
+                 href="/drugs-and-alcohol/?prisonerNumber=A1234DY" >
+                Drugs and alcohol
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-education-skills-and-work"
+                 href="/education-skills-and-work/?prisonerNumber=A1234DY" >
+                Education, skills and work
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-finance-and-id"
+                 href="/finance-and-id/?prisonerNumber=A1234DY" >
+                Finance and ID
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-health-status"
+                 href="/health-status/?prisonerNumber=A1234DY" >
+                Health
+              </a>
+            </li>
+          
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+
+  </div>
+
+
+    
+      <div class="govuk-width-container">
+        
+        <main class="govuk-main-wrapper app-container govuk-body" id="main-content">
+          
+<div class="govuk-grid-row govuk-!-padding-top-4 govuk-!-padding-bottom-0">
+  
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l" data-qa="page-title-h2">
+      Resettlement overview
+    </h2>
+    
+  </div>
+
+  
+  
+  
+</div>
+
+  <div class="govuk-grid-row govuk-!-padding-top-4">
+    <div class="govuk-grid-column-one-quarter sticky-anchor-links">
+      
+  <ul class="app-subnav__section">
+    <li class="app-subnav__section-item app-subnav__section-item--current">
+      <ul class="app-subnav__section app-subnav__section--nested">
+        
+          <li class="app-subnav__section-item">
+            <a href="#support-needs">Support needs statuses</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#staff-contacts">Staff contacts</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#case-notes">Case notes</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#appointments">Appointments</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#licence-summary">Licence conditions</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#risk-assessments">Risk assessments and predictors</a>
+          </li>
+        
+      </ul>
+    </li>
+  </ul>
+
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      
+        <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
+          <header class="app-summary-card__header">
+            <h3 class="app-summary-card__title">Support needs statuses</h3>
+          </header>
+          <div class="app-summary-card__body">
+            <table class="govuk-table govuk-!-margin-bottom-4">
+              <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Pathway</th>
+                <th scope="col" class="govuk-table__header">Responsible staff</th>
+                <th scope="col" class="govuk-table__header">Support need statuses</th>
+                <th scope="col" class="govuk-table__header">Last updated</th>
+              </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                
+              </tbody>
+            </table>
+          </div>
+        </section>
+      
+
+      
+      
+      <section id="staff-contacts" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Staff contacts
+          </h3>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4">
+          
+            <table class="govuk-table">
+              <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Key worker</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">Steve Rendell</td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Prison Offender Manager</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">David Jones</td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Community Offender Manager</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">John Doe</td>
+              </tr>
+              <tr class="govuk-table__row">
+                  <th class="govuk-table__header" scope="row">Resettlement Worker</th>
+                  <td class="govuk-table__cell govuk-table__cell--min-width-100">Pso Lastname</td>
+              </tr>
+              </tbody>
+            </table>
+          
+          <br>
+        </div>
+      </section>
+      <section id="case-notes" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Case notes<span class="govuk-caption-m">Filtered to Resettlement</span>
+          </h3>
+          
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4">
+          <div class="govuk-grid-row">
+            <form action="/prisoner-overview/#case-notes" method="GET" novalidate>
+              <input name="prisonerNumber" value="A1234DY" hidden />
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="pathway-select">Filter by pathway</label>
+                <select name="selectedPathway" class="govuk-select" id="pathway-select">
+                  <option selected value="All">All pathways</option>
+                  <option  value="ACCOMMODATION">
+                    Accommodation
+                  </option>
+                  <option 
+                          value="ATTITUDES_THINKING_AND_BEHAVIOUR">Attitudes, thinking and behaviour
+                  </option>
+                  <option 
+                          value="CHILDREN_FAMILIES_AND_COMMUNITY">Children, families and communities
+                  </option>
+                  <option  value="DRUGS_AND_ALCOHOL">
+                    Drugs and alcohol
+                  </option>
+                  <option 
+                          value="EDUCATION_SKILLS_AND_WORK">Education, skills and work
+                  </option>
+                  <option  value="FINANCE_AND_ID">Finance
+                    and ID
+                  </option>
+                  <option  value="HEALTH">Health</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="date-range-select">Filter by date range</label>
+                <select name="days" class="govuk-select" id="date-range-select">
+                  <option value="0" selected>All time</option>
+                  <option value="7" >Last week</option>
+                  <option value="30" >Last 4 weeks</option>
+                  <option value="84" >Last 12 weeks</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="sort-by-select">Sort by</label>
+                <select name="sort" class="govuk-select" id="sort-by-select">
+                  <option  value="occurenceDateTime,DESC">
+                    Created (most recent)
+                  </option>
+                  <option  value="pathway,ASC">Pathway</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <button class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-4" type="submit" data-prevent-double-click="true">Apply filters
+                </button>
+              </div>
+            </form>
+          </div>
+          <div class="govuk-grid-row govuk-!-padding-top-8">
+            <div class="govuk-grid-column-full" id="case-notes-container">
+              <hr>
+              
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Support declined.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+    <strong>Resettlement status set to: Support required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          Updating the status to support required.
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+    <strong>Resettlement status set to: Support not required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirecting test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirected to pathway page
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect to individual pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect form to pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test update redirect
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          form submit redirect to pathway
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                
+                
+                
+                
+                
+                  
+  
+  
+
+  <nav class="moj-pagination" aria-label="Pagination navigation">
+    <ul class="moj-pagination__list">
+      
+      
+      
+    </ul>
+    
+    
+      
+    
+    <p class="moj-pagination__results">Showing <b>1</b> to <b></b> of <b></b> results</p>
+  </nav>
+
+                
+              
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="appointments" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Appointments
+            <span class="govuk-caption-m">Post-release appointments</span>
+          </h3>
+          
+        </header>
+        <div class="app-summary-card__body">
+          
+            
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Title</th>
+                  <th scope="col" class="govuk-table__header">Contact</th>
+                  <th scope="col" class="govuk-table__header">Date</th>
+                  <th scope="col" class="govuk-table__header">Time</th>
+                  <th scope="col" class="govuk-table__header">Location</th>
+                </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Appointment with Charity ABC</td>
+                    <td class="govuk-table__cell">Bob Example</td>
+                    <td class="govuk-table__cell">31 Oct 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">SA1 1JG</td>
+                  </tr>
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Appointment with Jobs centre plus</td>
+                    <td class="govuk-table__cell">CRSUATU Staff</td>
+                    <td class="govuk-table__cell">1 Nov 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">Unit 7 Parc Tawe North,
+Swansea,
+SA1 2AA</td>
+                  </tr>
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Accommodation Services - North West</td>
+                    <td class="govuk-table__cell">Not provided</td>
+                    <td class="govuk-table__cell">1 Nov 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">9 Downing Street,
+Gwent,
+S1 2NP</td>
+                  </tr>
+                
+                </tbody>
+              </table>
+            
+          
+          <br>
+        </div>
+      </section>
+
+
+      <section id="licence-summary" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Licence conditions<span class="govuk-caption-m">Data sourced from CVL</span>
+          </h3>
+          <span class="right"></span>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4 govuk-!-padding-left-10">
+          
+            <details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Standard licence conditions
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    
+              <ol class="govuk-list govuk-list--number govuk-list--spaced">
+                
+                  <li>Be of good behaviour and not behave in a way which undermines the purpose of the licence period.
+                    
+                  </li>
+                
+                  <li>Not commit any offence.
+                    
+                  </li>
+                
+                  <li>Keep in touch with the supervising officer in accordance with instructions given by the supervising officer.
+                    
+                  </li>
+                
+              </ol>
+            
+  </div>
+</details>
+
+            
+              <h3 class="govuk-heading-s">Additional and bespoke licence conditions</h3>
+              <ol class="govuk-list govuk-list--number govuk-list--spaced govuk-!-padding-left-6"
+                  start="4">
+                
+                  <li>You must reside overnight within Greater Manchester probation region while of no fixed abode, unless otherwise approved by your supervising officer.
+                    
+                  </li>
+                
+                  <li>Not to enter the area of Leeds City Centre, as defined by the attached map, without the prior approval of your supervising officer.
+                    
+                      <a
+                          href="/licence-image/?licenceId=101&conditionId=1008&prisonerNumber=A1234DY"
+                          rel="noreferrer noopener"
+                          target="_blank">View map (opens in new tab)</a>
+                    
+                  </li>
+                
+                  <li>Report to staff at Victoria Park Probation Centre at 10:30am daily, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a monthly basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.
+                    
+                  </li>
+                
+                  <li>Attend a location, as required by your supervising officer, to give a sample of oral fluid / urine in order to test whether you have any specified Class A and specified Class B drugs in your body, for the purpose of ensuring that you are complying with the condition of your licence requiring you to be of good behaviour. Do not take any action that could hamper or frustrate the drug testing process.
+                    
+                  </li>
+                
+                  <li>Allow person(s) as designated by your supervising officer to install an electronic monitoring tag on you and access to install any associated equipment in your property, and for the purpose of ensuring that equipment is functioning correctly. You must not damage or tamper with these devices and ensure that the tag is charged, and report to your supervising officer and the EM provider immediately if the tag or the associated equipment are not working correctly. This will be for the purpose of monitoring your freedom of movement licence condition(s) unless otherwise authorised by your supervising officer.
+                    
+                  </li>
+                
+                  <li>You will be subject to trail monitoring. Your whereabouts will be electronically monitored by GPS Satellite Tagging, ending on 08 November 2024, and you must cooperate with the monitoring as directed by your supervising officer unless otherwise authorised by your supervising officer.
+                    
+                  </li>
+                
+                  <li>You must let the police search you if they ask. You must also let them search a vehicle you are with, like a car or a motorbike.
+                    
+                  </li>
+                
+              </ol>
+            
+          
+        </div>
+      </section>
+
+    
+      <section id="risk-assessments" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Risk assessments and predictors
+            <span class="govuk-caption-m">Data sourced from Assess Risks and Needs</span>
+          </h3>
+          <span class="right"></span>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4 govuk-!-padding-left-10">
+          <h3>Risk assessments and predictors</h3>
+          
+            <p class="govuk-body-s">Last updated: 29 July 2023</p>
+            <table class="govuk-table">
+              <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      LOW
+                      <span class="govuk-!-font-weight-regular">RSR</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      Low
+                      <span class="govuk-!-font-weight-regular">OGRS3</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      Low
+                      <span class="govuk-!-font-weight-regular">OVP</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__high">
+                      High
+                      <span class="govuk-!-font-weight-regular">OGP</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__medium">
+                      Medium
+                      <span class="govuk-!-font-weight-regular">OSP/I</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__medium">
+                      Medium
+                      <span class="govuk-!-font-weight-regular">OSP/C</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              </tbody>
+            </table>
+          
+          
+          <div class="rosh rosh__high">
+            
+              <h3>
+                
+                  High
+                  <span class="govuk-!-font-weight-regular">RoSH</span>
+                
+              </h3>
+              <p>Risk of serious harm</p>
+              <p class="govuk-body-s">Last updated: 29 July 2023</p>
+              <table class="govuk-table">
+                <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                  <th scope="row" class="govuk-table__header">
+                    Risk to
+                  </th>
+                  <td class="govuk-table__cell">
+                    <br />
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Children
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Public
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Known adult
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Staff
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__medium">
+                        Medium
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Prisoners
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__low">
+                        Low
+                      </strong>
+                    
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            
+          </div>
+          <div class="mappa-section">
+            
+              <h3>
+                CAT3 / LEVEL1
+                <span class="govuk-!-font-weight-regular">MAPPA</span>
+              </h3>
+              <p>Multi-agency public protection Arrangements</p>
+              <p class="govuk-body-s">Last updated: 27 January 2023</p>
+            
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+        </main>
+      </div>
+    
+
+    
+  
+    
+    <footer class="govuk-footer govuk-!-display-none-print"></footer>
+
+  
+
+
+    
+  
+  
+  <script type="module" src="/assets/govukFrontendInit.js"></script>
+  <script src="/assets/moj/all.js"></script>
+  <script src="/assets/mojFrontendInit.js"></script>
+
+
+  </body>
+</html>
+"
+`;
+
 exports[`prisonerOverview should display error when supportNeeds is enabled and support needs data is not retrieved 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
@@ -2630,6 +5715,1045 @@ exports[`prisonerOverview should display responsible staff data when supportNeed
                     </td>
                     <td class="govuk-table__cell">-</td>
                   </tr>
+                
+              </tbody>
+            </table>
+          </div>
+        </section>
+      
+
+      
+      
+      <section id="staff-contacts" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Staff contacts
+          </h3>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4">
+          
+            <table class="govuk-table">
+              <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Key worker</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">Steve Rendell</td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Prison Offender Manager</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">David Jones</td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row">Community Offender Manager</th>
+                <td class="govuk-table__cell govuk-table__cell--min-width-100">John Doe</td>
+              </tr>
+              <tr class="govuk-table__row">
+                  <th class="govuk-table__header" scope="row">Resettlement Worker</th>
+                  <td class="govuk-table__cell govuk-table__cell--min-width-100">Pso Lastname</td>
+              </tr>
+              </tbody>
+            </table>
+          
+          <br>
+        </div>
+      </section>
+      <section id="case-notes" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Case notes<span class="govuk-caption-m">Filtered to Resettlement</span>
+          </h3>
+          
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4">
+          <div class="govuk-grid-row">
+            <form action="/prisoner-overview/#case-notes" method="GET" novalidate>
+              <input name="prisonerNumber" value="A1234DY" hidden />
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="pathway-select">Filter by pathway</label>
+                <select name="selectedPathway" class="govuk-select" id="pathway-select">
+                  <option selected value="All">All pathways</option>
+                  <option  value="ACCOMMODATION">
+                    Accommodation
+                  </option>
+                  <option 
+                          value="ATTITUDES_THINKING_AND_BEHAVIOUR">Attitudes, thinking and behaviour
+                  </option>
+                  <option 
+                          value="CHILDREN_FAMILIES_AND_COMMUNITY">Children, families and communities
+                  </option>
+                  <option  value="DRUGS_AND_ALCOHOL">
+                    Drugs and alcohol
+                  </option>
+                  <option 
+                          value="EDUCATION_SKILLS_AND_WORK">Education, skills and work
+                  </option>
+                  <option  value="FINANCE_AND_ID">Finance
+                    and ID
+                  </option>
+                  <option  value="HEALTH">Health</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="date-range-select">Filter by date range</label>
+                <select name="days" class="govuk-select" id="date-range-select">
+                  <option value="0" selected>All time</option>
+                  <option value="7" >Last week</option>
+                  <option value="30" >Last 4 weeks</option>
+                  <option value="84" >Last 12 weeks</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <label class="govuk-label" for="sort-by-select">Sort by</label>
+                <select name="sort" class="govuk-select" id="sort-by-select">
+                  <option  value="occurenceDateTime,DESC">
+                    Created (most recent)
+                  </option>
+                  <option  value="pathway,ASC">Pathway</option>
+                </select>
+              </div>
+              <div class="govuk-grid-column-one-third">
+                <button class="govuk-button govuk-!-margin-bottom-0 govuk-!-margin-top-4" type="submit" data-prevent-double-click="true">Apply filters
+                </button>
+              </div>
+            </form>
+          </div>
+          <div class="govuk-grid-row govuk-!-padding-top-8">
+            <div class="govuk-grid-column-full" id="case-notes-container">
+              <hr>
+              
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Support declined.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Test user 3</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Accommodation</h3>
+  
+  
+    <strong>Resettlement status set to: Support required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          Updating the status to support required.
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 22 April 2024</span>
+  <span class="govuk-caption-m">Created: 22 April 2024 by Secondname, Firstname</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Health</h3>
+  
+  
+    <strong>Resettlement status set to: Support not required.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirecting test
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          redirected to pathway page
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Education, skills and work</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect to individual pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Finance and ID</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          testing redirect form to pathway...
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: In progress.</strong>
+  
+  
+      <p class="show-line-breaks">
+          test update redirect
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                  
+
+
+
+
+<div class="case-note">
+  
+    <h3>Attitudes, thinking and behaviour</h3>
+  
+  
+    <strong>Resettlement status set to: Done.</strong>
+  
+  
+      <p class="show-line-breaks">
+          form submit redirect to pathway
+      </p>
+  
+  <span class="govuk-caption-m">Happened: 19 April 2024</span>
+  <span class="govuk-caption-m">Created: 19 April 2024 by Test user</span>
+</div>
+                  <hr>
+                
+                
+                
+                
+                
+                
+                  
+  
+  
+
+  <nav class="moj-pagination" aria-label="Pagination navigation">
+    <ul class="moj-pagination__list">
+      
+      
+      
+    </ul>
+    
+    
+      
+    
+    <p class="moj-pagination__results">Showing <b>1</b> to <b></b> of <b></b> results</p>
+  </nav>
+
+                
+              
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="appointments" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Appointments
+            <span class="govuk-caption-m">Post-release appointments</span>
+          </h3>
+          
+        </header>
+        <div class="app-summary-card__body">
+          
+            
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Title</th>
+                  <th scope="col" class="govuk-table__header">Contact</th>
+                  <th scope="col" class="govuk-table__header">Date</th>
+                  <th scope="col" class="govuk-table__header">Time</th>
+                  <th scope="col" class="govuk-table__header">Location</th>
+                </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Appointment with Charity ABC</td>
+                    <td class="govuk-table__cell">Bob Example</td>
+                    <td class="govuk-table__cell">31 Oct 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">SA1 1JG</td>
+                  </tr>
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Appointment with Jobs centre plus</td>
+                    <td class="govuk-table__cell">CRSUATU Staff</td>
+                    <td class="govuk-table__cell">1 Nov 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">Unit 7 Parc Tawe North,
+Swansea,
+SA1 2AA</td>
+                  </tr>
+                
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Accommodation Services - North West</td>
+                    <td class="govuk-table__cell">Not provided</td>
+                    <td class="govuk-table__cell">1 Nov 2024</td>
+                    <td class="govuk-table__cell">15:18</td>
+                    <td class="govuk-table__cell show-line-breaks">9 Downing Street,
+Gwent,
+S1 2NP</td>
+                  </tr>
+                
+                </tbody>
+              </table>
+            
+          
+          <br>
+        </div>
+      </section>
+
+
+      <section id="licence-summary" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Licence conditions<span class="govuk-caption-m">Data sourced from CVL</span>
+          </h3>
+          <span class="right"></span>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4 govuk-!-padding-left-10">
+          
+            <details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Standard licence conditions
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    
+              <ol class="govuk-list govuk-list--number govuk-list--spaced">
+                
+                  <li>Be of good behaviour and not behave in a way which undermines the purpose of the licence period.
+                    
+                  </li>
+                
+                  <li>Not commit any offence.
+                    
+                  </li>
+                
+                  <li>Keep in touch with the supervising officer in accordance with instructions given by the supervising officer.
+                    
+                  </li>
+                
+              </ol>
+            
+  </div>
+</details>
+
+            
+              <h3 class="govuk-heading-s">Additional and bespoke licence conditions</h3>
+              <ol class="govuk-list govuk-list--number govuk-list--spaced govuk-!-padding-left-6"
+                  start="4">
+                
+                  <li>You must reside overnight within Greater Manchester probation region while of no fixed abode, unless otherwise approved by your supervising officer.
+                    
+                  </li>
+                
+                  <li>Not to enter the area of Leeds City Centre, as defined by the attached map, without the prior approval of your supervising officer.
+                    
+                      <a
+                          href="/licence-image/?licenceId=101&conditionId=1008&prisonerNumber=A1234DY"
+                          rel="noreferrer noopener"
+                          target="_blank">View map (opens in new tab)</a>
+                    
+                  </li>
+                
+                  <li>Report to staff at Victoria Park Probation Centre at 10:30am daily, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a monthly basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.
+                    
+                  </li>
+                
+                  <li>Attend a location, as required by your supervising officer, to give a sample of oral fluid / urine in order to test whether you have any specified Class A and specified Class B drugs in your body, for the purpose of ensuring that you are complying with the condition of your licence requiring you to be of good behaviour. Do not take any action that could hamper or frustrate the drug testing process.
+                    
+                  </li>
+                
+                  <li>Allow person(s) as designated by your supervising officer to install an electronic monitoring tag on you and access to install any associated equipment in your property, and for the purpose of ensuring that equipment is functioning correctly. You must not damage or tamper with these devices and ensure that the tag is charged, and report to your supervising officer and the EM provider immediately if the tag or the associated equipment are not working correctly. This will be for the purpose of monitoring your freedom of movement licence condition(s) unless otherwise authorised by your supervising officer.
+                    
+                  </li>
+                
+                  <li>You will be subject to trail monitoring. Your whereabouts will be electronically monitored by GPS Satellite Tagging, ending on 08 November 2024, and you must cooperate with the monitoring as directed by your supervising officer unless otherwise authorised by your supervising officer.
+                    
+                  </li>
+                
+                  <li>You must let the police search you if they ask. You must also let them search a vehicle you are with, like a car or a motorbike.
+                    
+                  </li>
+                
+              </ol>
+            
+          
+        </div>
+      </section>
+
+    
+      <section id="risk-assessments" class="app-summary-card govuk-!-margin-bottom-8">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Risk assessments and predictors
+            <span class="govuk-caption-m">Data sourced from Assess Risks and Needs</span>
+          </h3>
+          <span class="right"></span>
+        </header>
+        <div class="app-summary-card__body govuk-!-padding-top-4 govuk-!-padding-left-10">
+          <h3>Risk assessments and predictors</h3>
+          
+            <p class="govuk-body-s">Last updated: 29 July 2023</p>
+            <table class="govuk-table">
+              <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      LOW
+                      <span class="govuk-!-font-weight-regular">RSR</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      Low
+                      <span class="govuk-!-font-weight-regular">OGRS3</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__low">
+                      Low
+                      <span class="govuk-!-font-weight-regular">OVP</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__high">
+                      High
+                      <span class="govuk-!-font-weight-regular">OGP</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__medium">
+                      Medium
+                      <span class="govuk-!-font-weight-regular">OSP/I</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">
+                  
+                  
+                    <strong class="moj-badge moj-badge__medium">
+                      Medium
+                      <span class="govuk-!-font-weight-regular">OSP/C</span>
+                    </strong>
+                  
+                </th>
+              </tr>
+              </tbody>
+            </table>
+          
+          
+          <div class="rosh rosh__high">
+            
+              <h3>
+                
+                  High
+                  <span class="govuk-!-font-weight-regular">RoSH</span>
+                
+              </h3>
+              <p>Risk of serious harm</p>
+              <p class="govuk-body-s">Last updated: 29 July 2023</p>
+              <table class="govuk-table">
+                <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                  <th scope="row" class="govuk-table__header">
+                    Risk to
+                  </th>
+                  <td class="govuk-table__cell">
+                    <br />
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Children
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Public
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Known adult
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__high">
+                        High
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Staff
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__medium">
+                        Medium
+                      </strong>
+                    
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td scope="row" class="govuk-table__cell">
+                    Prisoners
+                  </td>
+                  <td class="govuk-table__cell">
+                    
+                    
+                      <strong class="rosh-text__low">
+                        Low
+                      </strong>
+                    
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            
+          </div>
+          <div class="mappa-section">
+            
+              <h3>
+                CAT3 / LEVEL1
+                <span class="govuk-!-font-weight-regular">MAPPA</span>
+              </h3>
+              <p>Multi-agency public protection Arrangements</p>
+              <p class="govuk-body-s">Last updated: 27 January 2023</p>
+            
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+        </main>
+      </div>
+    
+
+    
+  
+    
+    <footer class="govuk-footer govuk-!-display-none-print"></footer>
+
+  
+
+
+    
+  
+  
+  <script type="module" src="/assets/govukFrontendInit.js"></script>
+  <script src="/assets/moj/all.js"></script>
+  <script src="/assets/mojFrontendInit.js"></script>
+
+
+  </body>
+</html>
+"
+`;
+
+exports[`prisonerOverview should display tasks but NO "reset profile" button when readOnlyMode is true and tasksView is true 1`] = `
+"<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+  <head>
+    <meta charset="utf-8">
+    <title>Prepare someone for release - Resettlement overview
+</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+
+    
+      <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
+      <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">
+      <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
+      <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">
+      <link rel="manifest" href="/assets/manifest.json">
+    
+
+    
+  <link href="/assets/stylesheets/application.css?" rel="stylesheet" />
+  <script src="/assets/js/jquery.min.js"></script>
+  
+  <!--<![endif]-->
+  
+  
+  <script src="/assets/analytics.js" nonce=""></script>
+  <meta name="csrf-token" content="">
+
+    
+  </head>
+  <body class="govuk-template__body">
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    
+
+    
+      <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+    
+
+    
+  
+    
+    
+<header class="fallback-dps-header" role="banner">
+  <div class="fallback-dps-header__container">
+    <div class="fallback-dps-header__title">
+      <a class="fallback-dps-header__link fallback-dps-header__link--no-underline fallback-dps-header__title__service-name" href="#">
+        <svg role="presentation" focusable="false" class="fallback-dps-header__logo" xmlns="http://www.w3.org/2000/svg" width="41" height="30" viewBox="0 0 41 30">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M7.54677 9.20065C8.64351 9.65301 9.88802 9.13584 10.3347 8.05183C10.7839 6.97073 10.27 5.71374 9.17342 5.26352C8.09836 4.82212 6.84843 5.34938 6.40124 6.4349C5.95404 7.515 6.47121 8.76014 7.54677 9.20065Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M2.71865 12.0298C3.81564 12.4821 5.0599 11.965 5.50659 10.881C5.9558 9.79984 5.44191 8.54286 4.34529 8.09264C3.27023 7.65124 2.02031 8.17837 1.57311 9.26402C1.12592 10.3441 1.64308 11.5891 2.71865 12.0298Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M1.3065 17.397C2.4035 17.8494 3.648 17.3322 4.09469 16.2481C4.54391 15.1669 4.02977 13.91 2.9334 13.4599C1.85834 13.0183 0.608415 13.5457 0.160968 14.6311C-0.286227 15.7112 0.231192 16.9565 1.3065 17.397Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M12.9335 10.9018C14.0302 11.3542 15.2747 10.837 15.7214 9.75301C16.1706 8.6719 15.6568 7.41491 14.5601 6.96469C13.4851 6.52329 12.2351 7.05055 11.788 8.13607C11.3408 9.21617 11.8579 10.4613 12.9335 10.9018Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M32.4543 9.20065C31.3573 9.65301 30.1131 9.13584 29.6661 8.05183C29.2172 6.97073 29.7308 5.71374 30.8274 5.26352C31.9027 4.82212 33.1527 5.34938 33.5999 6.4349C34.0471 7.515 33.5299 8.76014 32.4543 9.20065Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M37.2805 12.0298C36.1833 12.4821 34.939 11.965 34.4923 10.881C34.0433 9.79984 34.557 8.54286 35.6536 8.09264C36.7289 7.65124 37.9788 8.17837 38.426 9.26402C38.8732 10.3441 38.3558 11.5891 37.2805 12.0298Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M38.6944 17.397C37.5977 17.8494 36.3532 17.3322 35.9065 16.2481C35.4573 15.1669 35.9712 13.91 37.0678 13.4599C38.1428 13.0183 39.3928 13.5457 39.84 14.6311C40.2874 15.7112 39.77 16.9565 38.6944 17.397Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M27.0657 10.9018C25.9687 11.3542 24.7244 10.837 24.2775 9.75301C23.8285 8.6719 24.3421 7.41491 25.4388 6.96469C26.5141 6.52329 27.764 7.05055 28.2112 8.13607C28.6584 9.21617 28.1412 10.4613 27.0657 10.9018Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M21.1246 5.39912L21.1311 5.39294L23.8259 6.80828V2.83635L21.1342 3.68851L21.1266 3.68044C21.0512 3.58147 20.9639 3.49284 20.8653 3.41656L20.858 3.40899L21.9407 0L19.9961 0.000252154L18.0507 0L19.1337 3.40899L19.1263 3.41656C19.0281 3.49284 18.9402 3.58147 18.8653 3.68044L18.8573 3.68851L16.166 2.83635V6.80828L18.8609 5.39294L18.8673 5.39912C18.9471 5.50351 19.0407 5.5963 19.1458 5.67498L17.5981 10.344C17.5962 10.3498 17.5942 10.3556 17.5925 10.3611L17.5908 10.366L17.5913 10.3666C17.5193 10.5997 17.4807 10.847 17.4807 11.1036C17.4807 12.3669 18.4127 13.4095 19.6264 13.5887C19.6445 13.5915 19.6621 13.5946 19.6804 13.5968C19.7838 13.61 19.8884 13.6188 19.9956 13.6188H19.9961H19.9964C20.1031 13.6188 20.2079 13.61 20.3116 13.5968C20.3295 13.5946 20.3472 13.5915 20.3655 13.5887C21.5788 13.4095 22.5112 12.3669 22.5112 11.1036C22.5112 10.847 22.4721 10.5997 22.4006 10.3666L22.4009 10.366L22.3994 10.3611C22.3975 10.3556 22.3955 10.3498 22.3935 10.344L20.8461 5.67498C20.951 5.5963 21.0448 5.50351 21.1246 5.39912Z"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M19.9961 28.2469C25.1126 28.2469 29.9557 28.5936 34.2707 29.2111C35.4958 24.0612 36.9865 21.1103 38.5258 19.0092L35.6272 17.978C35.9156 19.4496 35.9616 20.1346 35.6388 21.0806C35.1608 20.6133 34.7078 19.7539 34.3542 18.4405L32.95 23.1175C33.8045 22.529 34.4635 22.1489 35.2174 22.1306C33.8799 25.0107 32.2103 25.7519 31.1284 25.552C29.8069 25.3094 29.1998 24.1313 29.4046 23.1324C29.7085 21.7159 31.1616 21.3468 31.8404 22.994C33.1384 20.3461 30.9362 19.5212 29.5189 20.3045C31.6957 18.1333 31.9448 16.2036 30.1877 13.8682C27.7395 15.7394 27.7109 17.5926 28.8127 20.1999C27.383 18.5638 25.1586 19.4422 25.9621 22.0859C26.9932 20.4897 28.3578 21.4937 28.1436 23.0095C27.9627 24.3308 26.2183 25.3978 24.0464 25.2087C20.9338 24.9265 20.7484 22.7785 20.6709 21.0011C21.4362 20.8593 22.814 21.5684 23.9887 23.2183L24.4217 18.2575C23.1434 19.5894 21.9821 19.8421 20.6921 19.8829C21.1215 18.5433 23.0951 16.3481 23.0951 16.3481L20.2276 16.3478H20.2261H20.2248L16.9033 16.3481C16.9033 16.3481 18.877 18.5433 19.3061 19.8829C18.0163 19.8421 16.8551 19.5894 15.5765 18.2575L16.0097 23.2183C17.1847 21.5684 18.5623 20.8593 19.3276 21.0011C19.2503 22.7785 19.0648 24.9265 15.9521 25.2087C13.7802 25.3978 12.036 24.3308 11.8548 23.0095C11.6406 21.4937 13.0053 20.4897 14.0365 22.0859C14.8401 19.4422 12.6152 18.5638 11.186 20.1999C12.2877 17.5926 12.2587 15.7394 9.81076 13.8682C8.0535 16.2036 8.3025 18.1333 10.4793 20.3045C9.06211 19.5212 6.86005 20.3461 8.15814 22.994C8.83681 21.3468 10.2902 21.7159 10.5941 23.1324C10.7989 24.1313 10.1911 25.3094 8.87035 25.552C7.78836 25.7519 6.11859 25.0107 4.78117 22.1306C5.53523 22.1489 6.19361 22.529 7.04866 23.1175L5.64454 18.4405C5.29039 19.7539 4.8379 20.6133 4.35969 21.0806C4.03656 20.1346 4.08283 19.4496 4.37091 17.978L1.47266 19.0092C3.01218 21.11 4.50241 24.0607 5.72725 29.21C10.041 28.5931 14.8817 28.2469 19.9961 28.2469Z"/>
+        </svg>
+        Digital Prison Services
+      </a>
+
+      
+    </div>
+
+    <nav aria-label="Account navigation">
+      <ul class="fallback-dps-header__navigation">
+        
+          <li class="fallback-dps-header__navigation__item">
+            <span data-qa=header-user-name>F. Last</span>
+          </li>
+        
+
+        <li class="fallback-dps-header__navigation__item">
+          <a data-qa="signOut" class="fallback-dps-header__link fallback-dps-header__link--no-underline fallback-dps-header__sign-out" href="/sign-out">Sign out</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+  
+
+  <div class="govuk-width-container">
+    
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      BETA
+    </strong>
+    <span class="govuk-phase-banner__text">
+      This is a new service – your <a class="govuk-link" target="_blank" rel="noopener noreferrer"
+                                                            href="https://www.smartsurvey.co.uk/s/QQV2UP">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>
+
+    
+      
+    
+    
+      
+      
+    
+
+    
+  
+  
+
+  
+<nav class="govuk-breadcrumbs govuk-!-display-none-print govuk-breadcrumbs--collapse-on-mobile" aria-label="Breadcrumb">
+  <ol class="govuk-breadcrumbs__list">
+
+  
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="#">Digital Prison Services</a>
+    </li>
+  
+
+  
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/">Prepare someone for release</a>
+    </li>
+  
+
+  </ol>
+</nav>
+
+
+
+    <br />
+    
+      <span class="govuk-caption-xl">Prepare someone for release</span>
+      <h1 class="govuk-heading-xl" data-qa="page-heading">Resettlement record</h1>
+    
+
+    
+  <div class="govuk-grid-row profile-header">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+              <a href="/prisoner-overview/?prisonerNumber=A1234DY">
+                <img src="data:image/jpeg;base64, " alt="view prisoner profile"
+                     class="govuk-!-width-full profile-header__person-photo">
+              </a>
+            </div>
+            <div class="govuk-grid-column-three-quarters">
+              <h1 class="govuk-heading-xl" data-qa="profile-heading-full-name">
+                Smith, John
+                <span class="govuk-caption-l">A1234DY</span>
+                <p class="govuk-body-s govuk-!-padding-top-2">
+                  <a href="#/prisoner/A1234DY">View full DPS
+                    profile</a>
+                </p>
+              </h1>
+            </div>
+          </div>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half">
+              <p>
+                <b>Prisoner number:</b><br>
+                A1234DY</p>
+              <p>
+                <b>Location:</b>
+                
+              </p>
+              <p>
+                <b>Date of birth:</b>
+                29 Oct 1991
+                ()</p>
+            </div>
+            <div class="govuk-grid-column-one-half">
+              <p>
+                <b>Release date:</b>
+                30 Nov 2026
+                <br />
+                
+                
+                
+                
+                  (29 days)
+                
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+    
+
+
+  <div class="govuk-grid-row ">
+    <div class="govuk-grid-column-full">
+      <nav class="moj-sub-navigation" aria-label="Sub navigation">
+        <ul class="moj-sub-navigation__list">
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-prisoner-overview"
+                 href="/prisoner-overview/?prisonerNumber=A1234DY" aria-current=page>
+                Resettlement overview
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-accommodation"
+                 href="/accommodation/?prisonerNumber=A1234DY" >
+                Accommodation
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-attitudes-thinking-and-behaviour"
+                 href="/attitudes-thinking-and-behaviour/?prisonerNumber=A1234DY" >
+                Attitudes, thinking and behaviour
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-children-families-and-communities"
+                 href="/children-families-and-communities/?prisonerNumber=A1234DY" >
+                Children, families and communities
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-drugs-and-alcohol"
+                 href="/drugs-and-alcohol/?prisonerNumber=A1234DY" >
+                Drugs and alcohol
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-education-skills-and-work"
+                 href="/education-skills-and-work/?prisonerNumber=A1234DY" >
+                Education, skills and work
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-finance-and-id"
+                 href="/finance-and-id/?prisonerNumber=A1234DY" >
+                Finance and ID
+              </a>
+            </li>
+          
+            <li class="moj-sub-navigation__item">
+              <a class="moj-sub-navigation__link"
+                 data-qa="sub-nav-health-status"
+                 href="/health-status/?prisonerNumber=A1234DY" >
+                Health
+              </a>
+            </li>
+          
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+
+  </div>
+
+
+    
+      <div class="govuk-width-container">
+        
+        <main class="govuk-main-wrapper app-container govuk-body" id="main-content">
+          
+<div class="govuk-grid-row govuk-!-padding-top-4 govuk-!-padding-bottom-0">
+  
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l" data-qa="page-title-h2">
+      Resettlement overview
+    </h2>
+    
+  </div>
+
+  
+  
+  
+    
+  <div class="govuk-grid-column-one-third">
+    <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
+      <header class="app-summary-card__header">
+        <h3 class="app-summary-card__title">Actions:</h3>
+      </header>
+      <div class="app-summary-card__body">
+        
+        
+          <div class="govuk-form-group govuk-!-margin-0">
+            <input type="hidden" id="updated" name="updated" value="today">
+            <input type="hidden" id="pathway" name="pathway" value="attitudes">
+            <a id="generate-pdf-task-btn"  class="govuk-button govuk-button--primary" href="/print/packPdf?prisonerNumber=A1234DY" target="_blank">
+              Plan Your Future pack PDF
+            </a>
+          </div>
+          <div class="govuk-form-group govuk-!-margin-0">
+            <a id="generate-otp-task-btn" class="govuk-button govuk-button--primary" href="/print/otp?prisonerNumber=A1234DY">
+              Generate First-time ID code
+            </a>
+          </div>
+        
+      </div>
+    </section>
+  </div>
+
+  
+</div>
+
+  <div class="govuk-grid-row govuk-!-padding-top-4">
+    <div class="govuk-grid-column-one-quarter sticky-anchor-links">
+      
+  <ul class="app-subnav__section">
+    <li class="app-subnav__section-item app-subnav__section-item--current">
+      <ul class="app-subnav__section app-subnav__section--nested">
+        
+          <li class="app-subnav__section-item">
+            <a href="#support-needs">Support needs statuses</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#staff-contacts">Staff contacts</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#case-notes">Case notes</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#appointments">Appointments</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#licence-summary">Licence conditions</a>
+          </li>
+        
+          <li class="app-subnav__section-item">
+            <a href="#risk-assessments">Risk assessments and predictors</a>
+          </li>
+        
+      </ul>
+    </li>
+  </ul>
+
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      
+        <section id="support-needs" class="app-summary-card govuk-!-margin-bottom-8">
+          <header class="app-summary-card__header">
+            <h3 class="app-summary-card__title">Support needs statuses</h3>
+          </header>
+          <div class="app-summary-card__body">
+            <table class="govuk-table govuk-!-margin-bottom-4">
+              <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Pathway</th>
+                <th scope="col" class="govuk-table__header">Responsible staff</th>
+                <th scope="col" class="govuk-table__header">Support need statuses</th>
+                <th scope="col" class="govuk-table__header">Last updated</th>
+              </tr>
+              </thead>
+              <tbody class="govuk-table__body">
                 
               </tbody>
             </table>

--- a/server/routes/prisoner-overview/prisonerOverviewController.test.ts
+++ b/server/routes/prisoner-overview/prisonerOverviewController.test.ts
@@ -257,6 +257,50 @@ describe('prisonerOverview', () => {
       .expect(res => expect(res.text).toMatchSnapshot())
   })
 
+  it('should display "reset profile" button and other tasks when readOnlyMode is false and tasksView is true', async () => {
+    stubFeatureFlagToTrue(featureFlags, ['tasksView', 'profileReset', 'supportNeeds'])
+
+    stubPrisonerOverviewData(rpService)
+
+    await request(app)
+      .get('/prisoner-overview?prisonerNumber=A1234DY')
+      .expect(200)
+      .expect(res => expect(res.text).toMatchSnapshot())
+  })
+
+  it('should display "reset profile" button and NO other tasks when readOnlyMode is false and tasksView is false', async () => {
+    stubFeatureFlagToTrue(featureFlags, ['profileReset', 'supportNeeds'])
+
+    stubPrisonerOverviewData(rpService)
+
+    await request(app)
+      .get('/prisoner-overview?prisonerNumber=A1234DY')
+      .expect(200)
+      .expect(res => expect(res.text).toMatchSnapshot())
+  })
+
+  it('should display tasks but NO "reset profile" button when readOnlyMode is true and tasksView is true', async () => {
+    stubFeatureFlagToTrue(featureFlags, ['readOnlyMode', 'tasksView', 'profileReset', 'supportNeeds'])
+
+    stubPrisonerOverviewData(rpService)
+
+    await request(app)
+      .get('/prisoner-overview?prisonerNumber=A1234DY')
+      .expect(200)
+      .expect(res => expect(res.text).toMatchSnapshot())
+  })
+
+  it('should display NO "Action" box when readOnlyMode is true and tasksView is false', async () => {
+    stubFeatureFlagToTrue(featureFlags, ['readOnlyMode', 'profileReset', 'supportNeeds'])
+
+    stubPrisonerOverviewData(rpService)
+
+    await request(app)
+      .get('/prisoner-overview?prisonerNumber=A1234DY')
+      .expect(200)
+      .expect(res => expect(res.text).toMatchSnapshot())
+  })
+
   it('Error case - invalid page parameter', async () => {
     await request(app)
       .get('/prisoner-overview?prisonerNumber=A1234DY&page=InvalidValue')

--- a/server/routes/reset-profile/index.ts
+++ b/server/routes/reset-profile/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import ResetProfileController from './resetProfileController'
+import { readOnlyGuard } from '../readOnlyGuard'
 
 export default (router: Router, services: Services) => {
   const resetProfileController = new ResetProfileController(
@@ -8,8 +9,8 @@ export default (router: Router, services: Services) => {
     services.appInsightsService,
     services.prisonerDetailsService,
   )
-  router.get('/resetProfile', [resetProfileController.resetProfile])
-  router.get('/resetProfile/reason', [resetProfileController.resetProfileReason])
-  router.post('/resetProfile/reason', [resetProfileController.submitResetProfileReason])
-  router.get('/resetProfile/success', [resetProfileController.resetProfileSuccess])
+  router.get('/resetProfile', [readOnlyGuard, resetProfileController.resetProfile])
+  router.get('/resetProfile/reason', [readOnlyGuard, resetProfileController.resetProfileReason])
+  router.post('/resetProfile/reason', [readOnlyGuard, resetProfileController.submitResetProfileReason])
+  router.get('/resetProfile/success', [readOnlyGuard, resetProfileController.resetProfileSuccess])
 }

--- a/server/views/macros/tasks-details.njk
+++ b/server/views/macros/tasks-details.njk
@@ -1,11 +1,11 @@
-{% macro tasksDetails(prisonerNumber, tasksViewEnabled, csrfToken, resetProfileEnabled, supportNeedsEnabled) %}
+{% macro tasksDetails(prisonerNumber, tasksViewEnabled, csrfToken, resetProfileEnabled, supportNeedsEnabled, readOnlyMode) %}
   <div class="govuk-grid-column-one-third">
     <section id="pathway-status" class="app-summary-card govuk-!-margin-bottom-8">
       <header class="app-summary-card__header">
         <h3 class="app-summary-card__title">Actions:</h3>
       </header>
       <div class="app-summary-card__body">
-        {% if resetProfileEnabled %}
+        {% if resetProfileEnabled and not readOnlyMode %}
           <a href="/resetProfile?prisonerNumber={{prisonerNumber}}" class="govuk-button" id="reset-profile-btn" track-event-name="ResetReportsAndStatusesLinkClicked" track-event-prisoner-id="{{ prisonerNumber }}">
             Reset reports and {{ "support needs" if supportNeedsEnabled else "statuses" }}
           </a>

--- a/server/views/pages/overview.njk
+++ b/server/views/pages/overview.njk
@@ -14,6 +14,7 @@
 {% set resetProfileEnabled = features.RESET_PROFILE | getFeatureFlag %}
 {% set prisonerNumber = prisonerData.personalDetails.prisonerNumber %}
 {% set supportNeedsEnabled = features.SUPPORT_NEEDS | getFeatureFlag %}
+{% set readOnlyMode = features.READ_ONLY_MODE | getFeatureFlag %}
 
 {% set statusType = {
   name: "Support needs statuses" if supportNeedsEnabled else "Resettlement statuses",
@@ -69,7 +70,9 @@
   {% elif prisonerData.resettlementReviewAvailable === false %}
     {{preReleaseComplete(pathway, prisonerData)}}
   {% endif %}
-  {{ tasksDetails(prisonerNumber, tasksViewEnabled, csrfToken, resetProfileEnabled, supportNeedsEnabled) }}
+  {% if tasksViewEnabled or not readOnlyMode %}
+    {{ tasksDetails(prisonerNumber, tasksViewEnabled, csrfToken, resetProfileEnabled, supportNeedsEnabled, readOnlyMode) }}
+  {% endif %}
 </div>
 
   <div class="govuk-grid-row govuk-!-padding-top-4">


### PR DESCRIPTION
When in read-only mode:

- Remove 'reset profile' button.  (If this means the 'Actions' box will be empty, also remove the box)
- Send all related routes to 404 read-only page.