### PR TITLE
RSP-2047: Added UT for assign a case / staff capacity tab toggling

### DIFF
--- a/server/routes/staffDashboard/staffDashboardController.test.ts
+++ b/server/routes/staffDashboard/staffDashboardController.test.ts
@@ -7,7 +7,6 @@ import {
   stubPrisonerDetails,
   stubPrisonersList,
   stubNoPrisonersList,
-  stubFeatureFlagToFalse,
 } from '../testutils/testUtils'
 import { configHelper } from '../configHelperTest'
 import { appWithAllRoutes, mockedServices } from '../testutils/appSetup'


### PR DESCRIPTION
Added some UTs to confirm the tabs are shown / hidden depending on if the site is in read only mode or not