### PR TITLE
RSP-2052: Remove ability to change report info in read only mode

### DIFF
--- a/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
+++ b/server/routes/accommodation/__snapshots__/accommodationController.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getView "Add a support need" button should NOT be present when readOnlyMode = true 1`] = `
+exports[`getView Add and change links should NOT be present when readOnlyMode = true 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -907,9 +907,7 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -917,9 +915,7 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
           </tbody>
@@ -1173,7 +1169,7 @@ Answer3</td>
 "
 `;
 
-exports[`getView "Add a support need" button should be present when readOnlyMode = false 1`] = `
+exports[`getView Add and change links should be present when readOnlyMode = false 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -2086,9 +2082,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -2096,9 +2094,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -2944,9 +2944,11 @@ exports[`getView Happy path - ensure support need for legacy profile renders cor
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -2954,9 +2956,11 @@ exports[`getView Happy path - ensure support need for legacy profile renders cor
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -4123,9 +4127,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -4133,9 +4139,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -5791,9 +5799,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -5801,9 +5811,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ACCOMMODATION/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>

--- a/server/routes/accommodation/accommodationController.test.ts
+++ b/server/routes/accommodation/accommodationController.test.ts
@@ -159,7 +159,7 @@ describe('getView', () => {
     )
   })
 
-  it('"Add a support need" button should be present when readOnlyMode = false', async () => {
+  it('Add and change links should be present when readOnlyMode = false', async () => {
     stubCrsReferrals(rpService, 'ACCOMMODATION')
     stubAccommodation(rpService)
     stubAssessmentInformation(rpService)
@@ -174,7 +174,7 @@ describe('getView', () => {
       .expect(res => expect(res.text).toMatchSnapshot())
   })
 
-  it('"Add a support need" button should NOT be present when readOnlyMode = true', async () => {
+  it('Add and change links should NOT be present when readOnlyMode = true', async () => {
     stubFeatureFlagToTrue(featureFlags, ['readOnlyMode', 'supportNeeds'])
     stubCrsReferrals(rpService, 'ACCOMMODATION')
     stubAccommodation(rpService)

--- a/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
+++ b/server/routes/attitudes-thinking-behaviour/__snapshots__/attitudesThinkingBehaviourController.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getView "Add a support need" button should NOT be present when readOnlyMode = true 1`] = `
+exports[`getView Add and change links should NOT be present when readOnlyMode = true 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -832,9 +832,7 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -842,9 +840,7 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
           </tbody>
@@ -1098,7 +1094,7 @@ Answer3</td>
 "
 `;
 
-exports[`getView "Add a support need" button should be present when readOnlyMode = false 1`] = `
+exports[`getView Add and change links should be present when readOnlyMode = false 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -1936,9 +1932,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -1946,9 +1944,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -3040,9 +3040,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -3050,9 +3052,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -4597,9 +4601,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -4607,9 +4613,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/ATTITUDES_THINKING_AND_BEHAVIOUR/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>

--- a/server/routes/attitudes-thinking-behaviour/attitudesThinkingBehaviourController.test.ts
+++ b/server/routes/attitudes-thinking-behaviour/attitudesThinkingBehaviourController.test.ts
@@ -153,7 +153,7 @@ describe('getView', () => {
     )
   })
 
-  it('"Add a support need" button should be present when readOnlyMode = false', async () => {
+  it('Add and change links should be present when readOnlyMode = false', async () => {
     stubCrsReferrals(rpService, 'ATTITUDES_THINKING_AND_BEHAVIOUR')
     stubAssessmentInformation(rpService)
     stubCaseNotesHistory(rpService, 'ATTITUDES_THINKING_AND_BEHAVIOUR')
@@ -167,7 +167,7 @@ describe('getView', () => {
       .expect(res => expect(res.text).toMatchSnapshot())
   })
 
-  it('"Add a support need" button should NOT be present when readOnlyMode = true', async () => {
+  it('Add and change links should NOT be present when readOnlyMode = true', async () => {
     stubFeatureFlagToTrue(featureFlags, ['supportNeeds', 'readOnlyMode'])
     stubCrsReferrals(rpService, 'ATTITUDES_THINKING_AND_BEHAVIOUR')
     stubAssessmentInformation(rpService)

--- a/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
+++ b/server/routes/children-families-and-communities/__snapshots__/childrenFamiliesCommunitiesController.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getView "Add a support need" button should NOT be present when readOnlyMode = true 1`] = `
+exports[`getView Add and change links should NOT be present when readOnlyMode = true 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -832,9 +832,7 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -842,9 +840,7 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
           </tbody>
@@ -1098,7 +1094,7 @@ Answer3</td>
 "
 `;
 
-exports[`getView "Add a support need" button should be present when readOnlyMode = false 1`] = `
+exports[`getView Add and change links should be present when readOnlyMode = false 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -1936,9 +1932,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -1946,9 +1944,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -3211,9 +3211,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -3221,9 +3223,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -4768,9 +4772,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -4778,9 +4784,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/CHILDREN_FAMILIES_AND_COMMUNITY/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>

--- a/server/routes/children-families-and-communities/childrenFamiliesCommunitiesController.test.ts
+++ b/server/routes/children-families-and-communities/childrenFamiliesCommunitiesController.test.ts
@@ -153,7 +153,7 @@ describe('getView', () => {
     )
   })
 
-  it('"Add a support need" button should be present when readOnlyMode = false', async () => {
+  it('Add and change links should be present when readOnlyMode = false', async () => {
     stubCrsReferrals(rpService, 'CHILDREN_FAMILIES_AND_COMMUNITY')
     stubAssessmentInformation(rpService)
     stubCaseNotesHistory(rpService, 'CHILDREN_FAMILIES_AND_COMMUNITY')
@@ -167,7 +167,7 @@ describe('getView', () => {
       .expect(res => expect(res.text).toMatchSnapshot())
   })
 
-  it('"Add a support need" button should NOT be present when readOnlyMode = true', async () => {
+  it('Add and change links should NOT be present when readOnlyMode = true', async () => {
     stubFeatureFlagToTrue(featureFlags, ['supportNeeds', 'readOnlyMode'])
     stubCrsReferrals(rpService, 'CHILDREN_FAMILIES_AND_COMMUNITY')
     stubAssessmentInformation(rpService)

--- a/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
+++ b/server/routes/drugs-alcohol/__snapshots__/drugsAlcoholController.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getView "Add a support need" button should NOT be present when readOnlyMode = true 1`] = `
+exports[`getView Add and change links should NOT be present when readOnlyMode = true 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -832,9 +832,7 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -842,9 +840,7 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
           </tbody>
@@ -1098,7 +1094,7 @@ Answer3</td>
 "
 `;
 
-exports[`getView "Add a support need" button should be present when readOnlyMode = false 1`] = `
+exports[`getView Add and change links should be present when readOnlyMode = false 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -1936,9 +1932,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -1946,9 +1944,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -3211,9 +3211,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -3221,9 +3223,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -4768,9 +4772,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -4778,9 +4784,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/DRUGS_AND_ALCOHOL/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>

--- a/server/routes/drugs-alcohol/drugsAlcoholController.test.ts
+++ b/server/routes/drugs-alcohol/drugsAlcoholController.test.ts
@@ -153,7 +153,7 @@ describe('getView', () => {
     )
   })
 
-  it('"Add a support need" button should be present when readOnlyMode = false', async () => {
+  it('Add and change links should be present when readOnlyMode = false', async () => {
     stubCrsReferrals(rpService, 'DRUGS_AND_ALCOHOL')
     stubAssessmentInformation(rpService)
     stubCaseNotesHistory(rpService, 'DRUGS_AND_ALCOHOL')
@@ -167,7 +167,7 @@ describe('getView', () => {
       .expect(res => expect(res.text).toMatchSnapshot())
   })
 
-  it('"Add a support need" button should NOT be present when readOnlyMode = true', async () => {
+  it('Add and change links should NOT be present when readOnlyMode = true', async () => {
     stubFeatureFlagToTrue(featureFlags, ['supportNeeds', 'readOnlyMode'])
     stubCrsReferrals(rpService, 'DRUGS_AND_ALCOHOL')
     stubAssessmentInformation(rpService)

--- a/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
+++ b/server/routes/education-skills-work/__snapshots__/educationSkillsWorkController.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getView "Add a support need" button should NOT be present when readOnlyMode = true 1`] = `
+exports[`getView Add and change links should NOT be present when readOnlyMode = true 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -898,9 +898,7 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -908,9 +906,7 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
           </tbody>
@@ -1164,7 +1160,7 @@ Answer3</td>
 "
 `;
 
-exports[`getView "Add a support need" button should be present when readOnlyMode = false 1`] = `
+exports[`getView Add and change links should be present when readOnlyMode = false 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -2068,9 +2064,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -2078,9 +2076,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -3238,9 +3238,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -3248,9 +3250,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -4876,9 +4880,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -4886,9 +4892,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/EDUCATION_SKILLS_AND_WORK/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>

--- a/server/routes/education-skills-work/educationSkillsWorkController.test.ts
+++ b/server/routes/education-skills-work/educationSkillsWorkController.test.ts
@@ -160,7 +160,7 @@ describe('getView', () => {
     )
   })
 
-  it('"Add a support need" button should be present when readOnlyMode = false', async () => {
+  it('Add and change links should be present when readOnlyMode = false', async () => {
     stubCrsReferrals(rpService, 'EDUCATION_SKILLS_AND_WORK')
     stubAssessmentInformation(rpService)
     stubCaseNotesHistory(rpService, 'EDUCATION_SKILLS_AND_WORK')
@@ -175,7 +175,7 @@ describe('getView', () => {
       .expect(res => expect(res.text).toMatchSnapshot())
   })
 
-  it('"Add a support need" button should NOT be present when readOnlyMode = true', async () => {
+  it('Add and change links should NOT be present when readOnlyMode = true', async () => {
     stubFeatureFlagToTrue(featureFlags, ['supportNeeds', 'readOnlyMode'])
     stubCrsReferrals(rpService, 'EDUCATION_SKILLS_AND_WORK')
     stubAssessmentInformation(rpService)

--- a/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
+++ b/server/routes/finance-id/__snapshots__/financeIdController.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getView "Add a support need" button should NOT be present when readOnlyMode = true 1`] = `
+exports[`getView Add and change links should NOT be present when readOnlyMode = true 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -948,9 +948,7 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -958,9 +956,7 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
           </tbody>
@@ -1217,7 +1213,7 @@ Answer3</td>
 "
 `;
 
-exports[`getView "Add a support need" button should be present when readOnlyMode = false 1`] = `
+exports[`getView Add and change links should be present when readOnlyMode = false 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -2171,9 +2167,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -2181,9 +2179,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -3495,9 +3495,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -3505,9 +3507,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -5228,9 +5232,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -5238,9 +5244,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/FINANCE_AND_ID/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>

--- a/server/routes/finance-id/financeIdController.test.ts
+++ b/server/routes/finance-id/financeIdController.test.ts
@@ -168,7 +168,7 @@ describe('getView', () => {
     )
   })
 
-  it('"Add a support need" button should be present when readOnlyMode = false', async () => {
+  it('Add and change links should be present when readOnlyMode = false', async () => {
     stubCrsReferrals(rpService, 'FINANCE_AND_ID')
     stubAssessmentInformation(rpService)
     stubCaseNotesHistory(rpService, 'FINANCE_AND_ID')
@@ -184,7 +184,7 @@ describe('getView', () => {
       .expect(res => expect(res.text).toMatchSnapshot())
   })
 
-  it('"Add a support need" button should NOT be present when readOnlyMode = true', async () => {
+  it('Add and change links should NOT be present when readOnlyMode = true', async () => {
     stubFeatureFlagToTrue(featureFlags, ['supportNeeds', 'readOnlyMode'])
     stubCrsReferrals(rpService, 'FINANCE_AND_ID')
     stubAssessmentInformation(rpService)

--- a/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
+++ b/server/routes/health-status/__snapshots__/healthStatusController.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getView "Add a support need" button should NOT be present when readOnlyMode = true 1`] = `
+exports[`getView Add and change links should NOT be present when readOnlyMode = true 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -832,9 +832,7 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -842,9 +840,7 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
               </tr>
             
           </tbody>
@@ -1098,7 +1094,7 @@ Answer3</td>
 "
 `;
 
-exports[`getView "Add a support need" button should be present when readOnlyMode = false 1`] = `
+exports[`getView Add and change links should be present when readOnlyMode = false 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -1936,9 +1932,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -1946,9 +1944,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -3040,9 +3040,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -3050,9 +3052,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>
@@ -4597,9 +4601,11 @@ This is another new line</p>
               <tr class="govuk-table__row">
                 <th class="govuk-table__header" scope="row">This is a question</th>
                 <td class="govuk-table__cell show-line-breaks">Another answer</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_1/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
               <tr class="govuk-table__row">
@@ -4607,9 +4613,11 @@ This is another new line</p>
                 <td class="govuk-table__cell show-line-breaks">Answer1
 Answer2
 Answer3</td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
-                </td>
+                
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/HEALTH/page/PAGE_2/start-edit/?prisonerNumber=A1234DY&submitted=true&type=BCST2">Change</a>
+                  </td>
+                
               </tr>
             
           </tbody>

--- a/server/routes/health-status/healthStatusController.test.ts
+++ b/server/routes/health-status/healthStatusController.test.ts
@@ -132,7 +132,7 @@ describe('getView', () => {
     expect(getPathwaySupportNeedsUpdatesSpy).toHaveBeenCalledWith('A1234DY', 'HEALTH', 1, 10, 'createdDate,ASC', '')
   })
 
-  it('"Add a support need" button should be present when readOnlyMode = false', async () => {
+  it('Add and change links should be present when readOnlyMode = false', async () => {
     stubCrsReferrals(rpService, 'HEALTH')
     stubAssessmentInformation(rpService)
     stubCaseNotesHistory(rpService, 'HEALTH')
@@ -146,7 +146,7 @@ describe('getView', () => {
       .expect(res => expect(res.text).toMatchSnapshot())
   })
 
-  it('"Add a support need" button should NOT be present when readOnlyMode = true', async () => {
+  it('Add and change links should NOT be present when readOnlyMode = true', async () => {
     stubFeatureFlagToTrue(featureFlags, ['supportNeeds', 'readOnlyMode'])
     stubCrsReferrals(rpService, 'HEALTH')
     stubAssessmentInformation(rpService)

--- a/server/routes/immediate-needs-report/index.ts
+++ b/server/routes/immediate-needs-report/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import ImmediateNeedsReportController from './immediateNeedsReportController'
+import { readOnlyGuard } from '../readOnlyGuard'
 
 export default (router: Router, services: Services) => {
   const immediateNeedsReportController = new ImmediateNeedsReportController(
@@ -9,11 +10,21 @@ export default (router: Router, services: Services) => {
     services.prisonerDetailsService,
   )
 
-  router.get('/ImmediateNeedsReport-next-page', [immediateNeedsReportController.getFirstPage])
-  router.post('/ImmediateNeedsReport-next-page', [immediateNeedsReportController.saveAnswerAndGetNextPage])
+  router.get('/ImmediateNeedsReport-next-page', [readOnlyGuard, immediateNeedsReportController.getFirstPage])
+  router.post('/ImmediateNeedsReport-next-page', [
+    readOnlyGuard,
+    immediateNeedsReportController.saveAnswerAndGetNextPage,
+  ])
   router.get('/ImmediateNeedsReport/pathway/:pathway/page/:pageId/start-edit', [
+    readOnlyGuard,
     immediateNeedsReportController.startEdit,
   ])
-  router.get('/ImmediateNeedsReport/pathway/:pathway/page/:currentPageId', [immediateNeedsReportController.getView])
-  router.post('/ImmediateNeedsReport/pathway/:pathway/complete', [immediateNeedsReportController.completeAssessment])
+  router.get('/ImmediateNeedsReport/pathway/:pathway/page/:currentPageId', [
+    readOnlyGuard,
+    immediateNeedsReportController.getView,
+  ])
+  router.post('/ImmediateNeedsReport/pathway/:pathway/complete', [
+    readOnlyGuard,
+    immediateNeedsReportController.completeAssessment,
+  ])
 }

--- a/server/views/macros/assessmentInformation.njk
+++ b/server/views/macros/assessmentInformation.njk
@@ -1,4 +1,4 @@
-{% macro assessmentInformation(assessmentData, prisonerNumber, pathway) %}
+{% macro assessmentInformation(assessmentData, prisonerNumber, pathway, readOnlyMode) %}
   <section id="assessment-information" class="app-summary-card govuk-!-margin-bottom-8">
     <header class="app-summary-card__header">
       <h3 class="app-summary-card__title">Report information</h3>
@@ -28,9 +28,11 @@
                     {{ questionAnswer.answer }}
                   {%- endif -%}
                 </td>
-                <td class="govuk-table__cell">
-                  <a href="/ImmediateNeedsReport/pathway/{{ pathway | getEnumByName }}/page/{{ questionAnswer.originalPageId }}/start-edit/?prisonerNumber={{ prisonerNumber }}&submitted=true&type={{ assessmentData.latestAssessment.assessmentType }}">Change</a>
-                </td>
+                {% if not readOnlyMode %}
+                  <td class="govuk-table__cell">
+                    <a href="/ImmediateNeedsReport/pathway/{{ pathway | getEnumByName }}/page/{{ questionAnswer.originalPageId }}/start-edit/?prisonerNumber={{ prisonerNumber }}&submitted=true&type={{ assessmentData.latestAssessment.assessmentType }}">Change</a>
+                  </td>
+                {% endif %}
               </tr>
             {% endfor %}
           </tbody>

--- a/server/views/pages/accommodation.njk
+++ b/server/views/pages/accommodation.njk
@@ -128,7 +128,7 @@
           {% endif %}
         </div>
       </section>
-      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway) }}
+      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway, readOnlyMode) }}
       {% include "../partials/crsReferrals.njk" %}
     </div>
   </div>

--- a/server/views/pages/attitudes-thinking-behaviour.njk
+++ b/server/views/pages/attitudes-thinking-behaviour.njk
@@ -51,7 +51,7 @@
         {% include "../partials/supportNeedsUpdates.njk" %}
       {% endif %}
       {% include "../partials/caseNotes.njk" %}
-      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway) }}
+      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway, readOnlyMode) }}
       {% include "../partials/crsReferrals.njk" %}
     </div>
   </div>

--- a/server/views/pages/children-families-communities.njk
+++ b/server/views/pages/children-families-communities.njk
@@ -51,7 +51,7 @@
           {% include "../partials/supportNeedsUpdates.njk" %}
         {% endif %}
         {% include "../partials/caseNotes.njk" %}
-      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway) }}
+      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway, readOnlyMode) }}
       {% include "../partials/crsReferrals.njk" %}
     </div>
   </div>

--- a/server/views/pages/drugs-alcohol.njk
+++ b/server/views/pages/drugs-alcohol.njk
@@ -51,7 +51,7 @@
           {% include "../partials/supportNeedsUpdates.njk" %}
         {% endif %}
         {% include "../partials/caseNotes.njk" %}
-      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway) }}
+      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway, readOnlyMode) }}
       {% include "../partials/crsReferrals.njk" %}
     </div>
   </div>

--- a/server/views/pages/education-skills-work.njk
+++ b/server/views/pages/education-skills-work.njk
@@ -134,7 +134,7 @@
       {% else %}
         <p>{{ educationSkillsWork.error }}</p>
       {% endif %}
-      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway) }}
+      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway, readOnlyMode) }}
       {% include "../partials/crsReferrals.njk" %}
     </div>
   </div>

--- a/server/views/pages/finance-id.njk
+++ b/server/views/pages/finance-id.njk
@@ -328,7 +328,7 @@
           </div>
         </div>
       </section>
-      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway) }}
+      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway, readOnlyMode) }}
       {% include "../partials/crsReferrals.njk" %}
     </div>
   </div>

--- a/server/views/pages/health.njk
+++ b/server/views/pages/health.njk
@@ -51,7 +51,7 @@
         {% include "../partials/supportNeedsUpdates.njk" %}
       {% endif %}
       {% include "../partials/caseNotes.njk" %}
-      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway) }}
+      {{ assessmentInformation(assessmentData, prisonerData.personalDetails.prisonerNumber, pathway, readOnlyMode) }}
       {% include "../partials/crsReferrals.njk" %}
     </div>
   </div>


### PR DESCRIPTION
- Remove 'Change' links from Report Information panels
- Disable the change report routes