### PR TITLE
Fix playwright version to 1.54.1 in e2e test

### DIFF
--- a/.github/workflows/node_end_to_end_test.yml
+++ b/.github/workflows/node_end_to_end_test.yml
@@ -19,7 +19,8 @@ jobs:
         with:
           node-version-file: ${{ inputs.node_version_file }}
       - name: Install Playwright
-        run: npm install -g playwright && npx playwright install
+        run: |
+          npm install -g playwright@1.54.1 && npx playwright install
       - name: restore cache
         id: restore-cache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
Fixes playwright version to 1.54.1 in the e2e test, to ensure compatibility between playwright/chromium versions in the e2e test and cucumber.